### PR TITLE
Add number steps per train policy config

### DIFF
--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -29,6 +29,7 @@ class TrainingConfig(SubscriptableClass):
 
     number_steps_per_evaluation: Optional[int] = 10000
     number_eval_episodes: Optional[int] = 10
+    number_steps_per_train_policy: Optional[int] = 1
 
     plot_frequency: Optional[int] = 100
     checkpoint_frequency: Optional[int] = 100


### PR DESCRIPTION
Add support for number steps per train policy.

This helps to configure how frequent we are training the policy in relation to environment steps (step 32 times in environment then train policy G number of times)