### PR TITLE
Feature/normalization for mbrl

### DIFF
--- a/cares_reinforcement_learning/memory/memory_buffer.py
+++ b/cares_reinforcement_learning/memory/memory_buffer.py
@@ -40,29 +40,6 @@ class MemoryBuffer:
         transposed_batch = zip(*experience_batch)
         return transposed_batch
 
-    def sample_next(self, batch_size):
-        """
-        For training MBRL to predict rewards. The right next transition is
-        sampled as well. WHEN THE BUFFER IS NOT SHUFFLED.
-
-        (State, action, reward, next_state, next_action, next_reard)
-
-        """
-        batch_size = min(batch_size, len(self.buffer) - 1)
-        max_length = len(self.buffer)
-        idxs = np.random.randint(0, (max_length - 1), size=batch_size)
-        # A list of tuples
-        experience_batch = [
-            self.buffer[i]
-            + (
-                self.buffer[i + 1][1],
-                self.buffer[i + 1][2],
-            )
-            for i in idxs
-        ]
-        transposed_batch = zip(*experience_batch)
-        return transposed_batch
-
     def flush(self):
         """
         For on-policy PPO. Output all collected trajectories.

--- a/cares_reinforcement_learning/memory/memory_buffer.py
+++ b/cares_reinforcement_learning/memory/memory_buffer.py
@@ -1,8 +1,15 @@
 import random
 from collections import deque
+import numpy as np
 
 
 class MemoryBuffer:
+    """
+    A memory buffer to temporarily store transitions. It is like a transition
+    pool. Only off-policy algorithms needs random sampling this buffer.
+
+    """
+
     def __init__(self, max_capacity=int(1e6)):
         self.buffer = deque(maxlen=max_capacity)
 
@@ -10,18 +17,93 @@ class MemoryBuffer:
         return len(self.buffer)
 
     def add(self, *experience):
+        """
+        Add new transitions into the buffer. Be aware of the sequence. Should
+        be consistent with how it is sampled.
+
+        Example:
+
+        memory.add(state, action, reward, next_state, done)
+
+        :param experience: a tuple of a transition.
+        """
         self.buffer.append(experience)
 
     def sample(self, batch_size):
+        """
+        Sample for training the agent.
+
+        :param batch_size: It is pre-set by training configuration file.
+        """
         batch_size = min(batch_size, len(self.buffer))
         experience_batch = random.sample(self.buffer, batch_size)
         transposed_batch = zip(*experience_batch)
         return transposed_batch
 
+    def sample_next(self, batch_size):
+        """
+        For training MBRL to predict rewards. The right next transition is
+        sampled as well. WHEN THE BUFFER IS NOT SHUFFLED.
+
+        (State, action, reward, next_state, next_action, next_reard)
+
+        """
+        batch_size = min(batch_size, len(self.buffer) - 1)
+        max_length = len(self.buffer)
+        idxs = np.random.randint(0, (max_length - 1), size=batch_size)
+        # A list of tuples
+        experience_batch = [
+            self.buffer[i]
+            + (
+                self.buffer[i + 1][1],
+                self.buffer[i + 1][2],
+            )
+            for i in idxs
+        ]
+        transposed_batch = zip(*experience_batch)
+        return transposed_batch
+
     def flush(self):
+        """
+        For on-policy PPO. Output all collected trajectories.
+        And clear the buffer.
+
+        :return:
+        """
         experience = list(zip(*self.buffer))
         self.buffer.clear()
         return experience
 
     def clear(self):
+        """
+        Clear the buffer.
+        """
         self.buffer.clear()
+
+    def get_statistics(self):
+        """
+        Compute the statisitics for world model state normalization.
+        state, action, reward, next_state, done
+
+        :return: statistic tuple of the collected transitions.
+        """
+        states = [trans[0] for trans in self.buffer]
+        next_states = [trans[3] for trans in self.buffer]
+
+        states = np.array(states)
+        next_states = np.array(next_states)
+        delta = next_states - states
+
+        # Add a small number to avoid zeros.
+        observation_mean = np.mean(states, axis=0) + 0.00001
+        observation_std = np.std(states, axis=0) + 0.00001
+        delta_mean = np.mean(delta, axis=0) + 0.00001
+        delta_std = np.std(delta, axis=0) + 0.00001
+
+        statistics = {
+            "observation_mean": observation_mean,
+            "observation_std": observation_std,
+            "delta_mean": delta_mean,
+            "delta_std": delta_std,
+        }
+        return statistics

--- a/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
+++ b/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 import torch.utils
 from torch import optim
 import numpy as np
-from cares_reinforcement_learning.util.helpers import normalize_observations_deltas
+from cares_reinforcement_learning.util.helpers import normalize_observation_delta
 from cares_reinforcement_learning.networks.world_models.simple_dynamics import (
     SimpleDynamics,
 )
@@ -56,7 +56,7 @@ class IntegratedWorldModel:
         :param (Tensor) next_states -- target label.
         """
         target = next_states - states
-        delta_targets_normalized = normalize_observations_deltas(
+        delta_targets_normalized = normalize_observation_delta(
             target, self.statistics
         )
         _, n_mean, n_var = self.dyna_network.forward(states, actions)
@@ -85,7 +85,7 @@ class IntegratedWorldModel:
         # Always denormalized delta
         pred_next_state = mean_deltas + states
         target = next_states - states
-        delta_targets_normalized = normalize_observations_deltas(
+        delta_targets_normalized = normalize_observation_delta(
             target, self.statistics
         )
         model_loss = F.gaussian_nll_loss(

--- a/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
+++ b/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
@@ -56,9 +56,7 @@ class IntegratedWorldModel:
         :param (Tensor) next_states -- target label.
         """
         target = next_states - states
-        delta_targets_normalized = normalize_observation_delta(
-            target, self.statistics
-        )
+        delta_targets_normalized = normalize_observation_delta(target, self.statistics)
         _, n_mean, n_var = self.dyna_network.forward(states, actions)
         model_loss = F.gaussian_nll_loss(
             input=n_mean, target=delta_targets_normalized, var=n_var
@@ -85,9 +83,7 @@ class IntegratedWorldModel:
         # Always denormalized delta
         pred_next_state = mean_deltas + states
         target = next_states - states
-        delta_targets_normalized = normalize_observation_delta(
-            target, self.statistics
-        )
+        delta_targets_normalized = normalize_observation_delta(target, self.statistics)
         model_loss = F.gaussian_nll_loss(
             input=normalized_mean, target=delta_targets_normalized, var=normalized_var
         ).mean()

--- a/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
+++ b/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 import torch.utils
 from torch import optim
 import numpy as np
-from cares_reinforcement_learning.util.helpers import normalize_obs_deltas
+from cares_reinforcement_learning.util.helpers import normalize_observations_deltas
 from cares_reinforcement_learning.networks.world_models.simple_dynamics import (
     SimpleDynamics,
 )
@@ -56,7 +56,7 @@ class IntegratedWorldModel:
         :param (Tensor) next_states -- target label.
         """
         target = next_states - states
-        delta_targets_normalized = normalize_obs_deltas(target, self.statistics)
+        delta_targets_normalized = normalize_observations_deltas(target, self.statistics)
         _, n_mean, n_var = self.dyna_network.forward(states, actions)
         model_loss = F.gaussian_nll_loss(
             input=n_mean, target=delta_targets_normalized, var=n_var
@@ -83,7 +83,7 @@ class IntegratedWorldModel:
         # Always denormalized delta
         pred_next_state = mean_deltas + states
         target = next_states - states
-        delta_targets_normalized = normalize_obs_deltas(target, self.statistics)
+        delta_targets_normalized = normalize_observations_deltas(target, self.statistics)
         model_loss = F.gaussian_nll_loss(
             input=normalized_mean, target=delta_targets_normalized, var=normalized_var
         ).mean()

--- a/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
+++ b/cares_reinforcement_learning/networks/world_models/ensemble_integrated.py
@@ -56,7 +56,9 @@ class IntegratedWorldModel:
         :param (Tensor) next_states -- target label.
         """
         target = next_states - states
-        delta_targets_normalized = normalize_observations_deltas(target, self.statistics)
+        delta_targets_normalized = normalize_observations_deltas(
+            target, self.statistics
+        )
         _, n_mean, n_var = self.dyna_network.forward(states, actions)
         model_loss = F.gaussian_nll_loss(
             input=n_mean, target=delta_targets_normalized, var=n_var
@@ -83,7 +85,9 @@ class IntegratedWorldModel:
         # Always denormalized delta
         pred_next_state = mean_deltas + states
         target = next_states - states
-        delta_targets_normalized = normalize_observations_deltas(target, self.statistics)
+        delta_targets_normalized = normalize_observations_deltas(
+            target, self.statistics
+        )
         model_loss = F.gaussian_nll_loss(
             input=normalized_mean, target=delta_targets_normalized, var=normalized_var
         ).mean()

--- a/cares_reinforcement_learning/networks/world_models/simple_dynamics.py
+++ b/cares_reinforcement_learning/networks/world_models/simple_dynamics.py
@@ -4,8 +4,8 @@ import torch.nn.functional as F
 import torch.utils
 from cares_reinforcement_learning.util.helpers import (
     weight_init,
-    normalize_obs,
-    unnormalize_obs_deltas,
+    normalize_observations,
+    unnormalize_observations_deltas,
 )
 
 
@@ -54,7 +54,7 @@ class SimpleDynamics(nn.Module):
             obs.shape[1] + actions.shape[1] == self.observation_size + self.num_actions
         )
         # Always normalized obs
-        normalized_obs = normalize_obs(obs, self.statistics)
+        normalized_obs = normalize_observations(obs, self.statistics)
         x = torch.cat((normalized_obs, actions), dim=1)
         x = self.layer1(x)
         x = F.relu(x)
@@ -65,5 +65,5 @@ class SimpleDynamics(nn.Module):
         logvar = torch.tanh(logvar)
         normalized_var = torch.exp(logvar)
         # Always denormalized delta
-        mean_deltas = unnormalize_obs_deltas(normalized_mean, self.statistics)
+        mean_deltas = unnormalize_observations_deltas(normalized_mean, self.statistics)
         return mean_deltas, normalized_mean, normalized_var

--- a/cares_reinforcement_learning/networks/world_models/simple_dynamics.py
+++ b/cares_reinforcement_learning/networks/world_models/simple_dynamics.py
@@ -4,8 +4,8 @@ import torch.nn.functional as F
 import torch.utils
 from cares_reinforcement_learning.util.helpers import (
     weight_init,
-    normalize_observations,
-    unnormalize_observations_deltas,
+    normalize_observation,
+    denormalize_observation_delta,
 )
 
 
@@ -54,7 +54,7 @@ class SimpleDynamics(nn.Module):
             obs.shape[1] + actions.shape[1] == self.observation_size + self.num_actions
         )
         # Always normalized obs
-        normalized_obs = normalize_observations(obs, self.statistics)
+        normalized_obs = normalize_observation(obs, self.statistics)
         x = torch.cat((normalized_obs, actions), dim=1)
         x = self.layer1(x)
         x = F.relu(x)
@@ -65,5 +65,5 @@ class SimpleDynamics(nn.Module):
         logvar = torch.tanh(logvar)
         normalized_var = torch.exp(logvar)
         # Always denormalized delta
-        mean_deltas = unnormalize_observations_deltas(normalized_mean, self.statistics)
+        mean_deltas = denormalize_observation_delta(normalized_mean, self.statistics)
         return mean_deltas, normalized_mean, normalized_var

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -34,6 +34,39 @@ def weight_init(m):
         m.bias.data.fill_(0.0)
 
 
+def normalize_obs(obs, statistics):
+    """
+    This normalization is applied to world models inputs.
+    Normalize the states based on the statistics from experience replay.
+
+    Keyword arguments:
+        obs -- input states
+        statistics -- statistics from experience replay (no default)
+    """
+    return (obs - statistics["observation_mean"]) / statistics["observation_std"]
+
+
+def unnormalize_obs_deltas(normalized_deltas, statistics):
+    """
+    This denormlizing is applied to world models predicitons to restore the range of state difference between next and
+    current.
+
+    Keyword arguments:
+        obs -- input states
+        statistics -- statistics from experience replay (no default)
+    """
+    return (normalized_deltas * statistics["delta_std"]) + statistics["delta_mean"]
+
+
+def normalize_obs_deltas(deltas, statistics):
+    """
+    This normalization is applied to world models' target lables. The world model is predicting the difference between
+    current states and next states. This normalization is applied to the deltas.
+
+    """
+    return (deltas - statistics["delta_mean"]) / statistics["delta_std"]
+
+
 def denormalize(action, max_action_value, min_action_value):
     """
     return action in environment range [max_action_value, min_action_value]

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -43,7 +43,9 @@ def normalize_observation(observation, statistics):
         obs -- input states
         statistics -- statistics from experience replay (no default)
     """
-    return (observation - statistics["observation_mean"]) / statistics["observation_std"]
+    return (observation - statistics["observation_mean"]) / statistics[
+        "observation_std"
+    ]
 
 
 def denormalize_observation_delta(normalized_delta, statistics):

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -34,7 +34,7 @@ def weight_init(m):
         m.bias.data.fill_(0.0)
 
 
-def normalize_observations(obs, statistics):
+def normalize_observation(observation, statistics):
     """
     This normalization is applied to world models inputs.
     Normalize the states based on the statistics from experience replay.
@@ -43,10 +43,10 @@ def normalize_observations(obs, statistics):
         obs -- input states
         statistics -- statistics from experience replay (no default)
     """
-    return (obs - statistics["observation_mean"]) / statistics["observation_std"]
+    return (observation - statistics["observation_mean"]) / statistics["observation_std"]
 
 
-def unnormalize_observations_deltas(normalized_deltas, statistics):
+def denormalize_observation_delta(normalized_delta, statistics):
     """
     This denormlizing is applied to world models predicitons to restore the range of state difference between next and
     current.
@@ -55,16 +55,16 @@ def unnormalize_observations_deltas(normalized_deltas, statistics):
         obs -- input states
         statistics -- statistics from experience replay (no default)
     """
-    return (normalized_deltas * statistics["delta_std"]) + statistics["delta_mean"]
+    return (normalized_delta * statistics["delta_std"]) + statistics["delta_mean"]
 
 
-def normalize_observations_deltas(deltas, statistics):
+def normalize_observation_delta(delta, statistics):
     """
     This normalization is applied to world models' target lables. The world model is predicting the difference between
     current states and next states. This normalization is applied to the deltas.
 
     """
-    return (deltas - statistics["delta_mean"]) / statistics["delta_std"]
+    return (delta - statistics["delta_mean"]) / statistics["delta_std"]
 
 
 def denormalize(action, max_action_value, min_action_value):

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -34,7 +34,7 @@ def weight_init(m):
         m.bias.data.fill_(0.0)
 
 
-def normalize_obs(obs, statistics):
+def normalize_observations(obs, statistics):
     """
     This normalization is applied to world models inputs.
     Normalize the states based on the statistics from experience replay.
@@ -46,7 +46,7 @@ def normalize_obs(obs, statistics):
     return (obs - statistics["observation_mean"]) / statistics["observation_std"]
 
 
-def unnormalize_obs_deltas(normalized_deltas, statistics):
+def unnormalize_observations_deltas(normalized_deltas, statistics):
     """
     This denormlizing is applied to world models predicitons to restore the range of state difference between next and
     current.
@@ -58,7 +58,7 @@ def unnormalize_obs_deltas(normalized_deltas, statistics):
     return (normalized_deltas * statistics["delta_std"]) + statistics["delta_mean"]
 
 
-def normalize_obs_deltas(deltas, statistics):
+def normalize_observations_deltas(deltas, statistics):
     """
     This normalization is applied to world models' target lables. The world model is predicting the difference between
     current states and next states. This normalization is applied to the deltas.


### PR DESCRIPTION

Normalization of the states and prediction of state differences (next_state - curr_state) have been confirmed to help train a world model. 

This pull request: 
memory_buffer.py:
1. add a function to compute state statistics based on stored transitions. 

helpers.py:
1. add normalize and denormalize functions. (It is used in SimpleDynamic and EnsembleRewardWorld)