### PR TITLE
Fix a figure resize issue

### DIFF
--- a/cares_reinforcement_learning/util/plotter.py
+++ b/cares_reinforcement_learning/util/plotter.py
@@ -51,8 +51,11 @@ def plot_data(
     )
 
     plt.legend(fontsize="15", loc="upper left")
-    fig_manager = plt.get_current_fig_manager()
-    fig_manager.window.setGeometry(100, 100, 800, 650)
+
+    # Resize the plotted figure. Pixel = DPI * Inch.
+    fig = plt.gcf()
+    fig.set_dpi(100)
+    fig.set_size_inches(8, 6.5)
 
     plt.savefig(f"{directory}/figures/{filename}.png")
 

--- a/cares_reinforcement_learning/util/plotter.py
+++ b/cares_reinforcement_learning/util/plotter.py
@@ -52,10 +52,13 @@ def plot_data(
 
     plt.legend(fontsize="15", loc="upper left")
 
-    # Resize the plotted figure. Pixel = DPI * Inch.
+    # Resize the plotted figure. Pixel = DPI * Inch. PLT Default DPI: 100.
     fig = plt.gcf()
-    fig.set_dpi(100)
-    fig.set_size_inches(8, 6.5)
+    width= 800
+    height = 650
+    default_dpi = 100
+    fig.set_dpi(default_dpi)
+    fig.set_size_inches(width/default_dpi, height/default_dpi)
 
     plt.savefig(f"{directory}/figures/{filename}.png")
 

--- a/cares_reinforcement_learning/util/plotter.py
+++ b/cares_reinforcement_learning/util/plotter.py
@@ -54,11 +54,11 @@ def plot_data(
 
     # Resize the plotted figure. Pixel = DPI * Inch. PLT Default DPI: 100.
     fig = plt.gcf()
-    width= 800
+    width = 800
     height = 650
     default_dpi = 100
     fig.set_dpi(default_dpi)
-    fig.set_size_inches(width/default_dpi, height/default_dpi)
+    fig.set_size_inches(width / default_dpi, height / default_dpi)
 
     plt.savefig(f"{directory}/figures/{filename}.png")
 


### PR DESCRIPTION
The previous fig_manager used external libraries (QtWidgets) to resize. In some cases (when using a docker), those external libraries are hard to configure. This new commit uses matplotlib's own functions to set the figure's size.