### PR TITLE
TypeError create memory

### DIFF
--- a/cares_reinforcement_learning/memory/memory_buffer.py
+++ b/cares_reinforcement_learning/memory/memory_buffer.py
@@ -29,6 +29,29 @@ class MemoryBuffer:
         """
         self.buffer.append(experience)
 
+    def sample_next(self, batch_size):
+        """
+        For training MBRL to predict rewards. The right next transition is
+        sampled as well. WHEN THE BUFFER IS NOT SHUFFLED.
+
+        (State, action, reward, next_state, next_action, next_reard)
+
+        """
+        batch_size = min(batch_size, len(self.buffer) - 1)
+        max_length = len(self.buffer)
+        idxs = np.random.randint(0, (max_length - 1), size=batch_size)
+        # A list of tuples
+        experience_batch = [
+            self.buffer[i]
+            + (
+                self.buffer[i + 1][1],
+                self.buffer[i + 1][2],
+            )
+            for i in idxs
+        ]
+        transposed_batch = zip(*experience_batch)
+        return transposed_batch
+
     def sample(self, batch_size):
         """
         Sample for training the agent.

--- a/cares_reinforcement_learning/util/memory_factory.py
+++ b/cares_reinforcement_learning/util/memory_factory.py
@@ -6,7 +6,7 @@ from cares_reinforcement_learning.memory.augments import *
 
 
 class MemoryFactory:
-    def create_memory(self, memory_type, buffer_size, args):
+    def create_memory(self, memory_type, buffer_size):
         if memory_type == "MemoryBuffer":
             return MemoryBuffer(max_capacity=buffer_size)
         if memory_type == "PER":

--- a/cares_reinforcement_learning/util/plotter.py
+++ b/cares_reinforcement_learning/util/plotter.py
@@ -51,8 +51,11 @@ def plot_data(
     )
 
     plt.legend(fontsize="15", loc="upper left")
-    fig_manager = plt.get_current_fig_manager()
-    fig_manager.window.setGeometry(100, 100, 800, 650)
+
+    # Resize the plotted figure. Pixel = DPI * Inch.
+    fig = plt.gcf()
+    fig.set_dpi(100)
+    fig.set_size_inches(8, 6.5)
 
     plt.savefig(f"{directory}/figures/{filename}.png")
 


### PR DESCRIPTION
Receiving: TypeError: MemoryFactory.create_memory() got multiple values for argument 'args'.

Reason: args is a keyword in Python. Better avoid things like that.

Solution: Just remove it for now since no one is using it. When it is needed in the future, give it a different name. 