### PR TITLE
train reward and dynamic prediciton together

### DIFF
--- a/cares_reinforcement_learning/memory/memory_buffer.py
+++ b/cares_reinforcement_learning/memory/memory_buffer.py
@@ -29,6 +29,29 @@ class MemoryBuffer:
         """
         self.buffer.append(experience)
 
+    def sample_next(self, batch_size):
+        """
+        For training MBRL to predict rewards. The right next transition is
+        sampled as well. WHEN THE BUFFER IS NOT SHUFFLED.
+
+        (State, action, reward, next_state, next_action, next_reard)
+
+        """
+        batch_size = min(batch_size, len(self.buffer) - 1)
+        max_length = len(self.buffer)
+        idxs = np.random.randint(0, (max_length - 1), size=batch_size)
+        # A list of tuples
+        experience_batch = [
+            self.buffer[i]
+            + (
+                self.buffer[i + 1][1],
+                self.buffer[i + 1][2],
+            )
+            for i in idxs
+        ]
+        transposed_batch = zip(*experience_batch)
+        return transposed_batch
+
     def sample(self, batch_size):
         """
         Sample for training the agent.

--- a/cares_reinforcement_learning/util/plotter.py
+++ b/cares_reinforcement_learning/util/plotter.py
@@ -51,8 +51,11 @@ def plot_data(
     )
 
     plt.legend(fontsize="15", loc="upper left")
-    fig_manager = plt.get_current_fig_manager()
-    fig_manager.window.setGeometry(100, 100, 800, 650)
+
+    # Resize the plotted figure. Pixel = DPI * Inch.
+    fig = plt.gcf()
+    fig.set_dpi(100)
+    fig.set_size_inches(8, 6.5)
 
     plt.savefig(f"{directory}/figures/{filename}.png")
 


### PR DESCRIPTION
The current world model predicts both reward and dynamic (next states). Training needs the 'next actions' as input and the 'next rewards' as the reward network's target. A new sampling function is needed to extract the right next transition's action and reward. 

Therefore a new function is added in the MemoryBuffer for sampling. It samples transitions in the same manner as the normal one, but it will add the 'next action' and 'next reward' to the result for training MBRL.  


