### PR TITLE
Add an extra argument in TrainingConfig for training the world model

### DIFF
--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -19,8 +19,11 @@ class EnvironmentConfig(SubscriptableClass):
 
 class TrainingConfig(SubscriptableClass):
     seeds: List[int] = [10]
-
+    # for general agent training.
     G: Optional[int] = 1
+    # for training the world model in MBRL.
+    G_model: Optional[int] = 1
+
     buffer_size: Optional[int] = 1000000
     batch_size: Optional[int] = 256
 

--- a/cares_rl_configs/training_config.json
+++ b/cares_rl_configs/training_config.json
@@ -2,6 +2,7 @@
     "seeds": [10,20,30,40,50,60,70,80,90,100],
 
     "G":  1,
+    "G_model": 1,
     "batch_size": 10,
     
     "max_steps_exploration": 1000,


### PR DESCRIPTION
Add an extra argument in TrainingConfig for training the world model. The world model can be trained several times for each time step. Therefore a separate G is needed. 