### PR TITLE
Moved training config out of cares

### DIFF
--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -17,25 +17,6 @@ class EnvironmentConfig(SubscriptableClass):
     task: str
 
 
-class TrainingConfig(SubscriptableClass):
-    """
-    Configuration class for training.
-
-    Attributes:
-        seeds (List[int]): List of random seeds for reproducibility. Default is [10].
-        plot_frequency (Optional[int]): Frequency at which to plot training progress. Default is 100.
-        checkpoint_frequency (Optional[int]): Frequency at which to save model checkpoints. Default is 100.
-        number_steps_per_evaluation (Optional[int]): Number of steps per evaluation. Default is 10000.
-        number_eval_episodes (Optional[int]): Number of episodes to evaluate during training. Default is 10.
-    """
-
-    seeds: List[int] = [10]
-    plot_frequency: Optional[int] = 100
-    checkpoint_frequency: Optional[int] = 100
-    number_steps_per_evaluation: Optional[int] = 10000
-    number_eval_episodes: Optional[int] = 10
-
-
 class AlgorithmConfig(SubscriptableClass):
     """
     Configuration class for the algorithm.


### PR DESCRIPTION
This moves the training config out of the cares RL repo. Figured it makes sense for the training config and environment config to be in the repo which contains the `train.py` script as well as well as the environment itself.

Breaking change but simple fix. Instead of

```python
parser = RLParser(EnvironmentConfig)
```

you write

```python
parser = RLParser()
    
parser.add_configuration("env_config", EnvironmentConfig)
parser.add_configuration("training_config", TrainingConfig) # Note that you need to create this in the repo with train.py
```