### PR TITLE
Dev/model saving preferences

### DIFF
--- a/cares_reinforcement_learning/util/record.py
+++ b/cares_reinforcement_learning/util/record.py
@@ -47,6 +47,9 @@ class Record:
         self.plot_frequency = plot_frequency
         self.checkpoint_frequency = checkpoint_frequency
 
+        if checkpoint_frequency == None:
+            logging.warning("checkpoint_frequency not provided. Model will not be auto-saved and saving should be managed externally with save_model.")
+
         self.train_data_path = f"{self.directory}/data/train.csv"
         self.train_data = (
             pd.read_csv(self.train_data_path)

--- a/cares_reinforcement_learning/util/record.py
+++ b/cares_reinforcement_learning/util/record.py
@@ -47,7 +47,7 @@ class Record:
         self.plot_frequency = plot_frequency
         self.checkpoint_frequency = checkpoint_frequency
 
-        if checkpoint_frequency == None:
+        if self.checkpoint_frequency == None:
             logging.warning(
                 "checkpoint_frequency not provided. Model will not be auto-saved and saving should be managed externally with save_model."
             )

--- a/cares_reinforcement_learning/util/record.py
+++ b/cares_reinforcement_learning/util/record.py
@@ -48,7 +48,9 @@ class Record:
         self.checkpoint_frequency = checkpoint_frequency
 
         if checkpoint_frequency == None:
-            logging.warning("checkpoint_frequency not provided. Model will not be auto-saved and saving should be managed externally with save_model.")
+            logging.warning(
+                "checkpoint_frequency not provided. Model will not be auto-saved and saving should be managed externally with save_model."
+            )
 
         self.train_data_path = f"{self.directory}/data/train.csv"
         self.train_data = (

--- a/cares_reinforcement_learning/util/record.py
+++ b/cares_reinforcement_learning/util/record.py
@@ -21,7 +21,7 @@ class Record:
         algorithm (str): The algorithm name.
         task (str): The task name.
         plot_frequency (int, optional): The frequency at which to plot training data. Defaults to 10.
-        checkpoint_frequency (int, optional): The frequency at which to save model checkpoints. If not set model will not auto-save, use .save_model() externally to save.
+        checkpoint_frequency (int, optional): The frequency at which to save model checkpoints. If not set model will not auto-save, use save_model externally to save.
         network (Optional[nn.Module], optional): The neural network model. Defaults to None.
     """
 
@@ -130,7 +130,7 @@ class Record:
                 20,
             )
 
-        if self.network is not None and self.log_count % self.checkpoint_frequency == 0:
+        if (self.network is not None) and (self.checkpoint_frequency is not None) and (self.log_count % self.checkpoint_frequency == 0):
             self.network.save_models(
                 f"{self.algorithm}-checkpoint-{self.log_count}", self.directory
             )

--- a/cares_reinforcement_learning/util/record.py
+++ b/cares_reinforcement_learning/util/record.py
@@ -21,7 +21,7 @@ class Record:
         algorithm (str): The algorithm name.
         task (str): The task name.
         plot_frequency (int, optional): The frequency at which to plot training data. Defaults to 10.
-        checkpoint_frequency (int, optional): The frequency at which to save model checkpoints. Defaults to 1000.
+        checkpoint_frequency (int, optional): The frequency at which to save model checkpoints. If not set model will not auto-save, use .save_model() externally to save.
         network (Optional[nn.Module], optional): The neural network model. Defaults to None.
     """
 
@@ -32,7 +32,7 @@ class Record:
         algorithm: str,
         task: str,
         plot_frequency: int = 10,
-        checkpoint_frequency: int = 1000,
+        checkpoint_frequency: Optional[int] = None,
         network: Optional[nn.Module] = None,
     ) -> None:
 
@@ -97,6 +97,11 @@ class Record:
 
     def stop_video(self) -> None:
         self.video.release()
+
+    def save_model(self, identifier):
+        self.network.save_models(
+            f"{self.algorithm}-{identifier}", self.directory
+        )
 
     def log_video(self, frame: np.ndarray) -> None:
         self.video.write(frame)


### PR DESCRIPTION
Stop tying model saving directly to number of logs entered in Record class.
Rationale:
- Each entry into record is _typically_ an episode of some task. However in some task episode length may vary a lot during training. e.g. agent gets better at avoiding termination state and later episodes are significantly longer.
- This result in saving too many models in earlier stages and too few when the model is actually good.

Changes:
- Make auto saving frequency optional.
- Expose function to save a model explicitly so the saving behavior can be managed externally.