### PR TITLE
File config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,7 @@ The Record class allows data to be saved into a consistent format during trainin
 
 All data from a training run is saved into the directory specified in the `CARES_LOG_BASE_DIR` environment variable. If not specified, this will default to `'~/cares_rl_logs'`.
 
-You may specify a custom log directory format using the `log_path_template` config option. This path supports variable interpolation such as the algorithm used, seed, date etc. This defaults to `"{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"` so that each run is saved as a new seed under the algorithm and domain-task pair for that algorithm.
-
-Alternatively, instead of providing the `log_path_template` config option in the command line, you can set the `CARES_LOG_PATH_TEMPLATE` environment variable and this will be used instead. The environment variable will take precedence over the config option, mainly because it was easier to implement. It should probably be the other way around. Feel free to update the code accordingly
+You may specify a custom log directory format using the `CARES_LOG_PATH_TEMPLATE` environment variable. This path supports variable interpolation such as the algorithm used, seed, date etc. This defaults to `"{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"` so that each run is saved as a new seed under the algorithm and domain-task pair for that algorithm.
 
 The following variables are supported for log path template variable interpolation:
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ CARES RL provides a number of useful utility functions and classes for generatin
 
 The Record class allows data to be saved into a consistent format during training. This allows all data to be consistently formatted for plotting against each other for fair and consistent evaluation.
 
-All data from a training run is saved into the directory specified in the `CARES_LOG_DIR` environment variable. If not specified, this will default to `'~/cares_rl_logs'`.
+All data from a training run is saved into the directory specified in the `CARES_LOG_BASE_DIR` environment variable. If not specified, this will default to `'~/cares_rl_logs'`.
 
-You may specify a custom log directory format using the `log_path` config option. This path supports variable interpolation such as the algorithm used, seed, date etc. This defaults to `"{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"` so that each run is saved as a new seed under the algorithm and domain-task pair for that algorithm.
+You may specify a custom log directory format using the `log_path_template` config option. This path supports variable interpolation such as the algorithm used, seed, date etc. This defaults to `"{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"` so that each run is saved as a new seed under the algorithm and domain-task pair for that algorithm.
 
-The following variables are supported for `log_path` variable interpolation:
+Alternatively, instead of providing the `log_path_template` config option in the command line, you can set the `CARES_LOG_PATH_TEMPLATE` environment variable and this will be used instead. The environment variable will take precedence over the config option, mainly because it was easier to implement. It should probably be the other way around. Feel free to update the code accordingly
+
+The following variables are supported for log path template variable interpolation:
 
 - `algorithm`
 - `domain`

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -33,7 +33,6 @@ class TrainingConfig(SubscriptableClass):
     """
 
     seeds: List[int] = [10]
-    log_path_template: str = "{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"
     plot_frequency: Optional[int] = 100
     checkpoint_frequency: Optional[int] = 100
     number_steps_per_evaluation: Optional[int] = 10000

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -33,7 +33,7 @@ class TrainingConfig(SubscriptableClass):
     """
 
     seeds: List[int] = [10]
-    log_path: str = "{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"
+    log_path_template: str = "{algorithm}/{algorithm}-{domain_task}-{date}/{seed}"
     plot_frequency: Optional[int] = 100
     checkpoint_frequency: Optional[int] = 100
     number_steps_per_evaluation: Optional[int] = 10000

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -27,7 +27,7 @@ def create_path_from_format_string(
     :return: The path
     """
 
-    base_dir = os.environ.get("CARES_LOG_DIR", f"{Path.home()}/cares_rl_logs")
+    base_dir = os.environ.get("CARES_LOG_BASE_DIR", f"{Path.home()}/cares_rl_logs")
 
     domain_with_hyphen_or_empty = f"{domain}-" if domain != "" else ""
     domain_task = domain_with_hyphen_or_empty + task


### PR DESCRIPTION
I recently added a feature which allows you to provide custom log paths. I've since found that it was limited in the way that you had to provide the path via a cli argument which got tedious as this is quite a large argument. It also meant that you'd have inconsistent file structures in your log dir if you forgot to set the argument.

To fix this, I've made it use an environment variable instead which can be configured on a per-machine basis.

Use the `CARES_LOG_PATH_TEMPLATE` env variable to set a log directory