### PR TITLE
Soft update BatchNorm params to target as well

### DIFF
--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -88,6 +88,9 @@ def soft_update_params(net, target_net, tau):
     for param, target_param in zip(net.parameters(), target_net.parameters()):
         target_param.data.copy_(tau * param.data + (1 - tau) * target_param.data)
 
+    for param, target_param in zip(net.buffers(), target_net.buffers()):
+        target_param.data.copy_(tau * param.data + (1 - tau) * target_param.data)
+
 
 def weight_init(module: torch.nn.Module) -> None:
     """


### PR DESCRIPTION
Bug - bathcnorm parameters are not properly soft updated too target as they are not part of parameters but buffer. 