### PR TITLE
SACAE for 1D inputs

### DIFF
--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -222,6 +222,9 @@ class SACAE1D(VectorAlgorithm):
             reconstructed_data=reconstructed_data,
             latent_sample=latent_samples,
         )
+        
+        with open("ae_loss.txt", "a") as f:
+            f.write(f"{ae_loss.item()}\n")
 
         self.encoder_net_optimiser.zero_grad()
         self.decoder_net_optimiser.zero_grad()

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -1,0 +1,322 @@
+"""
+Original Paper: https://arxiv.org/abs/1910.01741
+Code based on: https://github.com/denisyarats/pytorch_sac_ae/tree/master
+
+This code runs automatic entropy tuning
+"""
+
+import copy
+import logging
+import os
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+import cares_reinforcement_learning.util.helpers as hlp
+from cares_reinforcement_learning.algorithm.algorithm import VectorAlgorithm
+from cares_reinforcement_learning.encoders.losses import AELoss
+from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
+from cares_reinforcement_learning.memory import MemoryBuffer
+from cares_reinforcement_learning.networks.SACAE import Actor, Critic
+from cares_reinforcement_learning.util.configurations import SACAEConfig
+
+
+class SACAE(VectorAlgorithm):
+    def __init__(
+        self,
+        actor_network: Actor,
+        critic_network: Critic,
+        decoder_network: Decoder,
+        config: SACAEConfig,
+        device: torch.device,
+    ):
+        super().__init__(policy_type="policy", config=config, device=device)
+
+        # this may be called policy_net in other implementations
+        self.actor_net = actor_network.to(device)
+
+        # this may be called soft_q_net in other implementations
+        self.critic_net = critic_network.to(device)
+        self.target_critic_net = copy.deepcopy(self.critic_net).to(device)
+        self.target_critic_net.eval()  # never in training mode - helps with batch/drop out layers
+
+        # tie the encoder weights
+        self.actor_net.encoder.copy_conv_weights_from(self.critic_net.encoder)
+
+        self.encoder_tau = config.encoder_tau
+
+        self.decoder_net = decoder_network.to(device)
+        self.decoder_update_freq = config.decoder_update_freq
+        self.decoder_latent_lambda = config.autoencoder_config.latent_lambda
+
+        self.gamma = config.gamma
+        self.tau = config.tau
+        self.reward_scale = config.reward_scale
+
+        # PER
+        self.use_per_buffer = config.use_per_buffer
+        self.per_sampling_strategy = config.per_sampling_strategy
+        self.per_weight_normalisation = config.per_weight_normalisation
+        self.per_alpha = config.per_alpha
+        self.min_priority = config.min_priority
+
+        self.learn_counter = 0
+        self.policy_update_freq = config.policy_update_freq
+        self.target_update_freq = config.target_update_freq
+
+        self.target_entropy = -self.actor_net.num_actions
+
+        self.actor_net_optimiser = torch.optim.Adam(
+            self.actor_net.parameters(), lr=config.actor_lr, **config.actor_lr_params
+        )
+        self.critic_net_optimiser = torch.optim.Adam(
+            self.critic_net.parameters(), lr=config.critic_lr, **config.critic_lr_params
+        )
+
+        self.ae_loss_function = AELoss(
+            latent_lambda=config.autoencoder_config.latent_lambda
+        )
+
+        self.encoder_net_optimiser = torch.optim.Adam(
+            self.critic_net.encoder.parameters(),
+            **config.autoencoder_config.encoder_optim_kwargs,
+        )
+        self.decoder_net_optimiser = torch.optim.Adam(
+            self.decoder_net.parameters(),
+            **config.autoencoder_config.decoder_optim_kwargs,
+        )
+
+        # Set to initial alpha to 1.0 according to other baselines.
+        init_temperature = 1.0
+        self.log_alpha = torch.tensor(np.log(init_temperature)).to(device)
+        self.log_alpha.requires_grad = True
+        self.log_alpha_optimizer = torch.optim.Adam(
+            [self.log_alpha], lr=config.alpha_lr, **config.alpha_lr_params
+        )
+
+    def select_action_from_policy(
+        self,
+        state: np.ndarray,
+        evaluation: bool = False,
+    ) -> np.ndarray:
+        # note that when evaluating this algorithm we need to select mu as action
+        self.actor_net.eval()
+        with torch.no_grad():
+            state_tensor = torch.FloatTensor(state).to(self.device)
+            state_tensor = state_tensor.unsqueeze(0)
+
+            if evaluation:
+                (_, _, action) = self.actor_net(state_tensor)
+            else:
+                (action, _, _) = self.actor_net(state_tensor)
+            action = action.cpu().data.numpy().flatten()
+        self.actor_net.train()
+        return action
+
+    @property
+    def alpha(self) -> torch.Tensor:
+        return self.log_alpha.exp()
+
+    def _update_critic(
+        self,
+        states: torch.Tensor,
+        actions: torch.Tensor,
+        rewards: torch.Tensor,
+        next_states: torch.Tensor,
+        dones: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> tuple[dict[str, Any], np.ndarray]:
+
+        with torch.no_grad():
+            with hlp.evaluating(self.actor_net):
+                next_actions, next_log_pi, _ = self.actor_net(next_states)
+
+            target_q_values_one, target_q_values_two = self.target_critic_net(
+                next_states, next_actions
+            )
+            target_q_values = (
+                torch.minimum(target_q_values_one, target_q_values_two)
+                - self.alpha * next_log_pi
+            )
+
+            q_target = (
+                rewards * self.reward_scale + self.gamma * (1 - dones) * target_q_values
+            )
+
+        q_values_one, q_values_two = self.critic_net(states, actions)
+
+        td_error_one = (q_values_one - q_target).abs()
+        td_error_two = (q_values_two - q_target).abs()
+
+        critic_loss_one = F.mse_loss(q_values_one, q_target, reduction="none")
+        critic_loss_one = (critic_loss_one * weights).mean()
+
+        critic_loss_two = F.mse_loss(q_values_two, q_target, reduction="none")
+        critic_loss_two = (critic_loss_two * weights).mean()
+
+        critic_loss_total = critic_loss_one + critic_loss_two
+
+        self.critic_net_optimiser.zero_grad()
+        critic_loss_total.backward()
+        self.critic_net_optimiser.step()
+
+        # Update the Priorities - PER only
+        priorities = (
+            torch.max(td_error_one, td_error_two)
+            .clamp(self.min_priority)
+            .pow(self.per_alpha)
+            .cpu()
+            .data.numpy()
+            .flatten()
+        )
+
+        info = {
+            "critic_loss_one": critic_loss_one.item(),
+            "critic_loss_two": critic_loss_two.item(),
+            "critic_loss_total": critic_loss_total.item(),
+        }
+
+        return info, priorities
+
+    def _update_actor_alpha(self, states:torch.Tensor) -> dict[str, Any]:
+        pi, log_pi, _ = self.actor_net(states, detach_encoder=True)
+
+        with hlp.evaluating(self.critic_net):
+            qf1_pi, qf2_pi = self.critic_net(states, pi, detach_encoder=True)
+
+        min_qf_pi = torch.minimum(qf1_pi, qf2_pi)
+        actor_loss = ((self.alpha * log_pi) - min_qf_pi).mean()
+
+        self.actor_net_optimiser.zero_grad()
+        actor_loss.backward()
+        self.actor_net_optimiser.step()
+
+        # Update the temperature (alpha)
+        alpha_loss = -(self.log_alpha * (log_pi + self.target_entropy).detach()).mean()
+
+        self.log_alpha_optimizer.zero_grad()
+        alpha_loss.backward()
+        self.log_alpha_optimizer.step()
+
+        info = {
+            "actor_loss": actor_loss.item(),
+            "alpha_loss": alpha_loss.item(),
+        }
+
+        return info
+
+    def _update_autoencoder(self, states: torch.Tensor) -> dict[str, Any]:
+        latent_samples = self.critic_net.encoder(states)
+        reconstructed_data = self.decoder_net(latent_samples)
+
+        ae_loss = self.ae_loss_function.calculate_loss(
+            data=states,
+            reconstructed_data=reconstructed_data,
+            latent_sample=latent_samples,
+        )
+
+        self.encoder_net_optimiser.zero_grad()
+        self.decoder_net_optimiser.zero_grad()
+        ae_loss.backward()
+        self.encoder_net_optimiser.step()
+        self.decoder_net_optimiser.step()
+
+        info = {
+            "ae_loss": ae_loss.item(),
+        }
+        return info
+
+    def train_policy(
+        self, memory: MemoryBuffer, batch_size: int, training_step: int
+    ) -> dict[str, Any]:
+        self.learn_counter += 1
+
+        if self.use_per_buffer:
+            experiences = memory.sample_priority(
+                batch_size,
+                sampling_stratagy=self.per_sampling_strategy,
+                weight_normalisation=self.per_weight_normalisation,
+            )
+            states, actions, rewards, next_states, dones, indices, weights = experiences
+        else:
+            experiences = memory.sample_uniform(batch_size)
+            states, actions, rewards, next_states, dones, _ = experiences
+            weights = [1.0] * batch_size
+
+        batch_size = len(states)
+
+        states_tensor = hlp.image_states_dict_to_tensor(states, self.device)
+
+        actions_tensor = torch.FloatTensor(np.asarray(actions)).to(self.device)
+        rewards_tensor = torch.FloatTensor(np.asarray(rewards)).to(self.device)
+
+        next_states_tensor = hlp.image_states_dict_to_tensor(next_states, self.device)
+
+        dones_tensor = torch.LongTensor(np.asarray(dones)).to(self.device)
+        weights_tensor = torch.FloatTensor(np.asarray(weights)).to(self.device)
+
+        # Reshape to batch_size x whatever
+        rewards_tensor = rewards_tensor.reshape(batch_size, 1)
+        dones_tensor = dones_tensor.reshape(batch_size, 1)
+        weights_tensor = weights_tensor.reshape(batch_size, 1)
+
+        info: dict[str, Any] = {}
+
+        # Update the Critic
+        critic_info, priorities = self._update_critic(
+            states_tensor,
+            actions_tensor,
+            rewards_tensor,
+            next_states_tensor,
+            dones_tensor,
+            weights_tensor,
+        )
+        info |= critic_info
+
+        # Update the Actor
+        if self.learn_counter % self.policy_update_freq == 0:
+            actor_info = self._update_actor_alpha(states_tensor)
+            info |= actor_info
+            info["alpha"] = self.alpha.item()
+
+        if self.learn_counter % self.target_update_freq == 0:
+            # Update the target networks - Soft Update
+            hlp.soft_update_params(
+                self.critic_net.critic.Q1, self.target_critic_net.critic.Q1, self.tau
+            )
+            hlp.soft_update_params(
+                self.critic_net.critic.Q2, self.target_critic_net.critic.Q2, self.tau
+            )
+            hlp.soft_update_params(
+                self.critic_net.encoder,
+                self.target_critic_net.encoder,
+                self.encoder_tau,
+            )
+
+        if self.learn_counter % self.decoder_update_freq == 0:
+            ae_info = self._update_autoencoder(states_tensor["image"])
+            info |= ae_info
+
+        # Update the Priorities
+        if self.use_per_buffer:
+            memory.update_priorities(indices, priorities)
+
+        return info
+
+    def save_models(self, filepath: str, filename: str) -> None:
+        if not os.path.exists(filepath):
+            os.makedirs(filepath)
+        torch.save(self.actor_net.state_dict(), f"{filepath}/{filename}_actor.pht")
+        torch.save(self.critic_net.state_dict(), f"{filepath}/{filename}_critic.pht")
+        torch.save(self.decoder_net.state_dict(), f"{filepath}/{filename}_decoder.pht")
+        logging.info("models has been saved...")
+
+    def load_models(self, filepath: str, filename: str) -> None:
+        self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
+        self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
+        self.decoder_net.load_state_dict(
+            torch.load(f"{filepath}/{filename}_decoder.pht")
+        )
+        logging.info("models has been loaded...")

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -106,7 +106,7 @@ class SACAE1D(VectorAlgorithm):
         with torch.no_grad():
             state_tensor = torch.FloatTensor(state).to(self.device)
             state_tensor = state_tensor.unsqueeze(0)
-
+            
             if evaluation:
                 (_, _, action) = self.actor_net(state_tensor)
             else:
@@ -210,7 +210,7 @@ class SACAE1D(VectorAlgorithm):
     def _update_autoencoder(self, states: torch.Tensor) -> dict[str, Any]:
         latent_samples = self.critic_net.encoder(states)
         reconstructed_data = self.decoder_net(latent_samples)
-
+        
         ae_loss = self.ae_loss_function.calculate_loss(
             data=states,
             reconstructed_data=reconstructed_data,
@@ -247,12 +247,12 @@ class SACAE1D(VectorAlgorithm):
 
         batch_size = len(states)
 
-        states_tensor = hlp.image_states_dict_to_tensor(states, self.device)
+        states_tensor = torch.FloatTensor(np.asarray(states)).to(self.device)
 
         actions_tensor = torch.FloatTensor(np.asarray(actions)).to(self.device)
         rewards_tensor = torch.FloatTensor(np.asarray(rewards)).to(self.device)
 
-        next_states_tensor = hlp.image_states_dict_to_tensor(next_states, self.device)
+        next_states_tensor = torch.FloatTensor(np.asarray(next_states)).to(self.device)
 
         dones_tensor = torch.LongTensor(np.asarray(dones)).to(self.device)
         weights_tensor = torch.FloatTensor(np.asarray(weights)).to(self.device)

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -20,16 +20,16 @@ from cares_reinforcement_learning.encoders.losses import AELoss
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
 from cares_reinforcement_learning.memory import MemoryBuffer
 from cares_reinforcement_learning.networks.SACAE import Actor, Critic
-from cares_reinforcement_learning.util.configurations import SACAEConfig
+from cares_reinforcement_learning.util.configurations import SACAE1DConfig
 
 
-class SACAE(VectorAlgorithm):
+class SACAE1D(VectorAlgorithm):
     def __init__(
         self,
         actor_network: Actor,
         critic_network: Critic,
         decoder_network: Decoder,
-        config: SACAEConfig,
+        config: SACAE1DConfig,
         device: torch.device,
     ):
         super().__init__(policy_type="policy", config=config, device=device)

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -296,7 +296,7 @@ class SACAE(VectorAlgorithm):
             )
 
         if self.learn_counter % self.decoder_update_freq == 0:
-            ae_info = self._update_autoencoder(states_tensor["image"])
+            ae_info = self._update_autoencoder(states_tensor)
             info |= ae_info
 
         # Update the Priorities

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -216,6 +216,9 @@ class SACAE1D(VectorAlgorithm):
             reconstructed_data=reconstructed_data,
             latent_sample=latent_samples,
         )
+        
+        with open("ae_loss.txt", "a") as f:
+            f.write(f"{ae_loss.item()}\n")
 
         self.encoder_net_optimiser.zero_grad()
         self.decoder_net_optimiser.zero_grad()

--- a/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE1D.py
@@ -329,9 +329,14 @@ class SACAE1D(VectorAlgorithm):
         logging.info("models has been saved...")
 
     def load_models(self, filepath: str, filename: str) -> None:
-        self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
-        self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
-        self.decoder_net.load_state_dict(
-            torch.load(f"{filepath}/{filename}_decoder.pht")
-        )
+        if torch.cuda.is_available():
+            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
+            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
+            self.decoder_net.load_state_dict(
+                torch.load(f"{filepath}/{filename}_decoder.pht")
+            )
+        else:
+            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"), map_location=torch.device('cpu'))
+            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"), map_location=torch.device('cpu'))
+            self.decoder_net.load_state_dict(torch.load(f"{filepath}/{filename}_decoder.pht"), map_location=torch.device('cpu'))
         logging.info("models has been loaded...")

--- a/cares_reinforcement_learning/algorithm/policy/TD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD3.py
@@ -300,9 +300,22 @@ class TD3(VectorAlgorithm):
 
     def load_models(self, filepath: str, filename: str) -> None:
         if torch.cuda.is_available():
-            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
-            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
+            self.actor_net.load_state_dict(
+                torch.load(f"{filepath}/{filename}_actor.pht")
+            )
+            self.critic_net.load_state_dict(
+                torch.load(f"{filepath}/{filename}_critic.pht")
+            )
         else:
-            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht", map_location=torch.device('cpu')))
-            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht", map_location=torch.device('cpu')))
+            self.actor_net.load_state_dict(
+                torch.load(
+                    f"{filepath}/{filename}_actor.pht", map_location=torch.device("cpu")
+                )
+            )
+            self.critic_net.load_state_dict(
+                torch.load(
+                    f"{filepath}/{filename}_critic.pht",
+                    map_location=torch.device("cpu"),
+                )
+            )
         logging.info("models has been loaded...")

--- a/cares_reinforcement_learning/algorithm/policy/TD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD3.py
@@ -299,6 +299,10 @@ class TD3(VectorAlgorithm):
         logging.info("models has been saved...")
 
     def load_models(self, filepath: str, filename: str) -> None:
-        self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht", map_location=torch.device('cpu')))
-        self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht", map_location=torch.device('cpu')))
+        if torch.cuda.is_available():
+            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
+            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
+        else:
+            self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht", map_location=torch.device('cpu')))
+            self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht", map_location=torch.device('cpu')))
         logging.info("models has been loaded...")

--- a/cares_reinforcement_learning/algorithm/policy/TD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD3.py
@@ -274,6 +274,6 @@ class TD3(VectorAlgorithm):
         logging.info("models has been saved...")
 
     def load_models(self, filepath: str, filename: str) -> None:
-        self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht"))
-        self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht"))
+        self.actor_net.load_state_dict(torch.load(f"{filepath}/{filename}_actor.pht", map_location=torch.device('cpu')))
+        self.critic_net.load_state_dict(torch.load(f"{filepath}/{filename}_critic.pht", map_location=torch.device('cpu')))
         logging.info("models has been loaded...")

--- a/cares_reinforcement_learning/encoders/losses.py
+++ b/cares_reinforcement_learning/encoders/losses.py
@@ -611,7 +611,7 @@ def _reconstruction_loss(
         Per image cross entropy (i.e. normalized per batch but not pixel and
         channel)
     """
-    
+
     # Check reconstructed_data dimensions
     if len(reconstructed_data.shape) == 4:
         # This is an image

--- a/cares_reinforcement_learning/encoders/losses.py
+++ b/cares_reinforcement_learning/encoders/losses.py
@@ -45,6 +45,7 @@ class AELoss:
             The calculated loss.
 
         """
+
         rec_loss = _reconstruction_loss(
             data, reconstructed_data, distribution=ReconDist.GAUSSIAN
         )
@@ -610,7 +611,19 @@ def _reconstruction_loss(
         Per image cross entropy (i.e. normalized per batch but not pixel and
         channel)
     """
-    batch_size, _, _, _ = reconstructed_data.size()
+    
+    # Check reconstructed_data dimensions
+    if len(reconstructed_data.shape) == 4:
+        # This is an image
+        batch_size, _, _, _ = reconstructed_data.size()
+    elif len(reconstructed_data.shape) == 2:
+        # This is a vector
+        batch_size, _ = reconstructed_data.size()
+    else:
+        raise ValueError(
+            f"Invalid shape for reconstructed_data: {reconstructed_data.shape}. "
+            "Expected 2D or 4D tensor."
+        )
 
     if distribution == ReconDist.BERNOULLI:
         loss = (

--- a/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
+++ b/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
@@ -313,8 +313,7 @@ class Encoder1D(nn.Module):
             ]
         )
 
-        print(f"Input observation size: {observation_size}")
-        
+         
         self.out_dim = hlp.flatten(observation_size, k=self.kernel_size, s=2)
 
         for _ in range(self.num_layers - 1):
@@ -329,8 +328,7 @@ class Encoder1D(nn.Module):
             self.out_dim = hlp.flatten(self.out_dim, k=self.kernel_size, s=1)
 
         self.n_flatten = self.out_dim * self.num_filters
-        print(f"Flattened output dimension: {self.out_dim} {self.num_filters} {self.n_flatten}")
-
+  
         self.fc = nn.Linear(self.n_flatten, self.latent_dim)
         self.ln = nn.LayerNorm(self.latent_dim)
 
@@ -342,22 +340,18 @@ class Encoder1D(nn.Module):
     def _forward_conv(self, x: torch.Tensor) -> torch.Tensor:
         # x should be of shape (batch_size, channels, sequence_length)
         conv = torch.relu(self.convs[0](x))
-        print(f"Shape after conv[0]: {conv.shape}")
         for i in range(1, self.num_layers):
             conv = torch.relu(self.convs[i](conv))
-            print(f"Shape after conv[{i}]: {conv.shape}")
         h = torch.flatten(conv, start_dim=1)
-        print(f"Flattened shape: {h.shape}")
         return h
     
     def forward(
-        self, obs: torch.Tensor, detach_cnn: bool = False, detach_output: bool = False
+        self, obs: torch.Tensor, detach_cnn: bool = True, detach_output: bool = True
     ) -> torch.Tensor:
         # Ensure input has correct shape for 1D conv: (batch_size, channels, sequence_length)
         if obs.dim() == 2:  # If input is (batch_size, sequence_length)
             obs = obs.unsqueeze(1)  # Add channel dimension: (batch_size, 1, sequence_length)
         
-        print(f"Input observation shape in forward: {obs.shape}")
         h = self._forward_conv(obs)
 
         # SAC AE detaches at the CNN layer

--- a/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
+++ b/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
@@ -411,7 +411,7 @@ class Decoder1D(nn.Module):
                 out_channels=output_channels,
                 kernel_size=self.kernel_size,
                 stride=2,
-                output_padding=1,
+                # output_padding=1,
             )
         )
 

--- a/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
+++ b/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
@@ -313,6 +313,8 @@ class Encoder1D(nn.Module):
             ]
         )
 
+        print(f"Input observation size: {observation_size}")
+        
         self.out_dim = hlp.flatten(observation_size, k=self.kernel_size, s=2)
 
         for _ in range(self.num_layers - 1):
@@ -327,6 +329,7 @@ class Encoder1D(nn.Module):
             self.out_dim = hlp.flatten(self.out_dim, k=self.kernel_size, s=1)
 
         self.n_flatten = self.out_dim * self.num_filters
+        print(f"Flattened output dimension: {self.out_dim} {self.num_filters} {self.n_flatten}")
 
         self.fc = nn.Linear(self.n_flatten, self.latent_dim)
         self.ln = nn.LayerNorm(self.latent_dim)
@@ -339,11 +342,14 @@ class Encoder1D(nn.Module):
     def _forward_conv(self, x: torch.Tensor) -> torch.Tensor:
         # x should be of shape (batch_size, channels, sequence_length)
         conv = torch.relu(self.convs[0](x))
+        print(f"Shape after conv[0]: {conv.shape}")
         for i in range(1, self.num_layers):
             conv = torch.relu(self.convs[i](conv))
+            print(f"Shape after conv[{i}]: {conv.shape}")
         h = torch.flatten(conv, start_dim=1)
+        print(f"Flattened shape: {h.shape}")
         return h
-
+    
     def forward(
         self, obs: torch.Tensor, detach_cnn: bool = False, detach_output: bool = False
     ) -> torch.Tensor:
@@ -351,6 +357,7 @@ class Encoder1D(nn.Module):
         if obs.dim() == 2:  # If input is (batch_size, sequence_length)
             obs = obs.unsqueeze(1)  # Add channel dimension: (batch_size, 1, sequence_length)
         
+        print(f"Input observation shape in forward: {obs.shape}")
         h = self._forward_conv(obs)
 
         # SAC AE detaches at the CNN layer

--- a/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
+++ b/cares_reinforcement_learning/encoders/vanilla_autoencoder.py
@@ -283,6 +283,7 @@ class Decoder(nn.Module):
 
         return observation
 
+
 class Encoder1D(nn.Module):
     def __init__(
         self,
@@ -301,7 +302,7 @@ class Encoder1D(nn.Module):
 
         # We assume input has 1 channel
         input_channels = 1
-        
+
         self.convs = nn.ModuleList(
             [
                 nn.Conv1d(
@@ -313,7 +314,6 @@ class Encoder1D(nn.Module):
             ]
         )
 
-         
         self.out_dim = hlp.flatten(observation_size, k=self.kernel_size, s=2)
 
         for _ in range(self.num_layers - 1):
@@ -328,7 +328,7 @@ class Encoder1D(nn.Module):
             self.out_dim = hlp.flatten(self.out_dim, k=self.kernel_size, s=1)
 
         self.n_flatten = self.out_dim * self.num_filters
-  
+
         self.fc = nn.Linear(self.n_flatten, self.latent_dim)
         self.ln = nn.LayerNorm(self.latent_dim)
 
@@ -344,14 +344,16 @@ class Encoder1D(nn.Module):
             conv = torch.relu(self.convs[i](conv))
         h = torch.flatten(conv, start_dim=1)
         return h
-    
+
     def forward(
         self, obs: torch.Tensor, detach_cnn: bool = True, detach_output: bool = True
     ) -> torch.Tensor:
         # Ensure input has correct shape for 1D conv: (batch_size, channels, sequence_length)
         if obs.dim() == 2:  # If input is (batch_size, sequence_length)
-            obs = obs.unsqueeze(1)  # Add channel dimension: (batch_size, 1, sequence_length)
-        
+            obs = obs.unsqueeze(
+                1
+            )  # Add channel dimension: (batch_size, 1, sequence_length)
+
         h = self._forward_conv(obs)
 
         # SAC AE detaches at the CNN layer
@@ -427,7 +429,7 @@ class Decoder1D(nn.Module):
             deconv = torch.relu(self.deconvs[i](deconv))
 
         observation = torch.sigmoid(self.deconvs[-1](deconv))
-        
+
         # Remove channel dimension if output should be (batch_size, sequence_length)
         if observation.size(1) == 1:
             observation = observation.squeeze(1)

--- a/cares_reinforcement_learning/networks/SACAE1D/__init__.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/__init__.py
@@ -1,0 +1,2 @@
+from .actor import Actor
+from .critic import Critic

--- a/cares_reinforcement_learning/networks/SACAE1D/actor.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/actor.py
@@ -41,6 +41,7 @@ class Actor(EncoderPolicy1D):
 
         ae_config = config.autoencoder_config
         if isinstance(observation_size, dict):
+            print(f"\n\nObservation size in actor: {observation_size['lidar']} {observation_size['vector']}\n\n")   # 683
             encoder = Encoder1D(
                 observation_size["lidar"],
                 latent_dim=ae_config.latent_dim,
@@ -59,8 +60,7 @@ class Actor(EncoderPolicy1D):
 
         actor_observation_size = encoder.latent_dim
         if config.vector_observation:
-            actor_observation_size += observation_size["vector"]
-
+            actor_observation_size += observation_size["vector"]    # 52: 2 vector + reduced lidar
         actor = SACActor(actor_observation_size, num_actions, config)
 
         super().__init__(

--- a/cares_reinforcement_learning/networks/SACAE1D/actor.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/actor.py
@@ -1,11 +1,11 @@
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import Encoder1D
 from cares_reinforcement_learning.networks.SAC import Actor as SACActor
 from cares_reinforcement_learning.networks.SAC import DefaultActor as DefaultSACActor
-from cares_reinforcement_learning.networks.common import EncoderPolicy
+from cares_reinforcement_learning.networks.common import EncoderPolicy1D
 from cares_reinforcement_learning.util.configurations import SACAE1DConfig
 
 
-class DefaultActor(EncoderPolicy):
+class DefaultActor(EncoderPolicy1D):
     def __init__(self, observation_size: int, num_actions: int):
 
         encoder = Encoder1D(
@@ -26,7 +26,7 @@ class DefaultActor(EncoderPolicy):
         )
 
 
-class Actor(EncoderPolicy):
+class Actor(EncoderPolicy1D):
     def __init__(self, observation_size: int, num_actions: int, config: SACAE1DConfig):
 
         ae_config = config.autoencoder_config

--- a/cares_reinforcement_learning/networks/SACAE1D/actor.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/actor.py
@@ -1,0 +1,49 @@
+from cares_reinforcement_learning.encoders.vanilla_autoencoder import Encoder1D
+from cares_reinforcement_learning.networks.SAC import Actor as SACActor
+from cares_reinforcement_learning.networks.SAC import DefaultActor as DefaultSACActor
+from cares_reinforcement_learning.networks.common import EncoderPolicy
+from cares_reinforcement_learning.util.configurations import SACAE1DConfig
+
+
+class DefaultActor(EncoderPolicy):
+    def __init__(self, observation_size: int, num_actions: int):
+
+        encoder = Encoder1D(
+            observation_size,
+            latent_dim=50,
+            num_layers=4,
+            num_filters=32,
+            kernel_size=3,
+        )
+
+        actor = DefaultSACActor(
+            encoder.latent_dim, num_actions, hidden_sizes=[1024, 1024]
+        )
+
+        super().__init__(
+            encoder,
+            actor,
+        )
+
+
+class Actor(EncoderPolicy):
+    def __init__(self, observation_size: int, num_actions: int, config: SACAE1DConfig):
+
+        ae_config = config.autoencoder_config
+        encoder = Encoder1D(
+            observation_size,
+            latent_dim=ae_config.latent_dim,
+            num_layers=ae_config.num_layers,
+            num_filters=ae_config.num_filters,
+            kernel_size=ae_config.kernel_size,
+        )
+
+        actor_observation_size = encoder.latent_dim
+
+        actor = SACActor(actor_observation_size, num_actions, config)
+
+        super().__init__(
+            encoder=encoder,
+            actor=actor,
+            add_vector_observation=bool(config.vector_observation),
+        )

--- a/cares_reinforcement_learning/networks/SACAE1D/actor.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/actor.py
@@ -37,7 +37,9 @@ class DefaultActor(EncoderPolicy1D):
 
 
 class Actor(EncoderPolicy1D):
-    def __init__(self, observation_size: int | dict, num_actions: int, config: SACAE1DConfig):
+    def __init__(
+        self, observation_size: int | dict, num_actions: int, config: SACAE1DConfig
+    ):
 
         ae_config = config.autoencoder_config
         if isinstance(observation_size, dict):
@@ -59,7 +61,9 @@ class Actor(EncoderPolicy1D):
 
         actor_observation_size = encoder.latent_dim
         if config.vector_observation:
-            actor_observation_size += observation_size["vector"]    # 52: 2 vector + reduced lidar
+            actor_observation_size += observation_size[
+                "vector"
+            ]  # 52: 2 vector + reduced lidar
         actor = SACActor(actor_observation_size, num_actions, config)
         super().__init__(
             encoder=encoder,

--- a/cares_reinforcement_learning/networks/SACAE1D/actor.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/actor.py
@@ -41,7 +41,6 @@ class Actor(EncoderPolicy1D):
 
         ae_config = config.autoencoder_config
         if isinstance(observation_size, dict):
-            print(f"\n\nObservation size in actor: {observation_size['lidar']} {observation_size['vector']}\n\n")   # 683
             encoder = Encoder1D(
                 observation_size["lidar"],
                 latent_dim=ae_config.latent_dim,
@@ -62,7 +61,6 @@ class Actor(EncoderPolicy1D):
         if config.vector_observation:
             actor_observation_size += observation_size["vector"]    # 52: 2 vector + reduced lidar
         actor = SACActor(actor_observation_size, num_actions, config)
-
         super().__init__(
             encoder=encoder,
             actor=actor,

--- a/cares_reinforcement_learning/networks/SACAE1D/critic.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/critic.py
@@ -24,11 +24,12 @@ class DefaultCritic(EncoderCritic1D):
 
 
 class Critic(EncoderCritic1D):
-    def __init__(self, observation_size: int | dict, num_actions: int, config: SACAE1DConfig):
+    def __init__(
+        self, observation_size: int | dict, num_actions: int, config: SACAE1DConfig
+    ):
 
         ae_config = config.autoencoder_config
-        
-        
+
         if isinstance(observation_size, dict):
             encoder = Encoder1D(
                 observation_size["lidar"],

--- a/cares_reinforcement_learning/networks/SACAE1D/critic.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/critic.py
@@ -30,7 +30,6 @@ class Critic(EncoderCritic1D):
         
         
         if isinstance(observation_size, dict):
-            print(f"\n\nObservation size in critic: {observation_size['lidar']} {observation_size['vector']}\n\n")  # 683
             encoder = Encoder1D(
                 observation_size["lidar"],
                 latent_dim=ae_config.latent_dim,
@@ -48,6 +47,8 @@ class Critic(EncoderCritic1D):
             )
 
         critic_observation_size = encoder.latent_dim
+        if config.vector_observation:
+            critic_observation_size += observation_size["vector"]
 
         critic = SACCritic(critic_observation_size, num_actions, config)
 

--- a/cares_reinforcement_learning/networks/SACAE1D/critic.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/critic.py
@@ -1,11 +1,11 @@
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import Encoder1D
 from cares_reinforcement_learning.networks.SAC import Critic as SACCritic
 from cares_reinforcement_learning.networks.SAC import DefaultCritic as DefaultSACCritic
-from cares_reinforcement_learning.networks.common import EncoderCritic
+from cares_reinforcement_learning.networks.common import EncoderCritic1D
 from cares_reinforcement_learning.util.configurations import SACAE1DConfig
 
 
-class DefaultCritic(EncoderCritic):
+class DefaultCritic(EncoderCritic1D):
     def __init__(self, observation_size: int, num_actions: int):
 
         encoder = Encoder1D(
@@ -23,7 +23,7 @@ class DefaultCritic(EncoderCritic):
         super().__init__(encoder, critic)
 
 
-class Critic(EncoderCritic):
+class Critic(EncoderCritic1D):
     def __init__(self, observation_size: int, num_actions: int, config: SACAE1DConfig):
 
         ae_config = config.autoencoder_config

--- a/cares_reinforcement_learning/networks/SACAE1D/critic.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/critic.py
@@ -24,16 +24,28 @@ class DefaultCritic(EncoderCritic1D):
 
 
 class Critic(EncoderCritic1D):
-    def __init__(self, observation_size: int, num_actions: int, config: SACAE1DConfig):
+    def __init__(self, observation_size: int | dict, num_actions: int, config: SACAE1DConfig):
 
         ae_config = config.autoencoder_config
-        encoder = Encoder1D(
-            observation_size,
-            latent_dim=ae_config.latent_dim,
-            num_layers=ae_config.num_layers,
-            num_filters=ae_config.num_filters,
-            kernel_size=ae_config.kernel_size,
-        )
+        
+        
+        if isinstance(observation_size, dict):
+            print(f"\n\nObservation size in critic: {observation_size['lidar']} {observation_size['vector']}\n\n")  # 683
+            encoder = Encoder1D(
+                observation_size["lidar"],
+                latent_dim=ae_config.latent_dim,
+                num_layers=ae_config.num_layers,
+                num_filters=ae_config.num_filters,
+                kernel_size=ae_config.kernel_size,
+            )
+        else:
+            encoder = Encoder1D(
+                observation_size,
+                latent_dim=ae_config.latent_dim,
+                num_layers=ae_config.num_layers,
+                num_filters=ae_config.num_filters,
+                kernel_size=ae_config.kernel_size,
+            )
 
         critic_observation_size = encoder.latent_dim
 

--- a/cares_reinforcement_learning/networks/SACAE1D/critic.py
+++ b/cares_reinforcement_learning/networks/SACAE1D/critic.py
@@ -1,0 +1,46 @@
+from cares_reinforcement_learning.encoders.vanilla_autoencoder import Encoder1D
+from cares_reinforcement_learning.networks.SAC import Critic as SACCritic
+from cares_reinforcement_learning.networks.SAC import DefaultCritic as DefaultSACCritic
+from cares_reinforcement_learning.networks.common import EncoderCritic
+from cares_reinforcement_learning.util.configurations import SACAE1DConfig
+
+
+class DefaultCritic(EncoderCritic):
+    def __init__(self, observation_size: int, num_actions: int):
+
+        encoder = Encoder1D(
+            observation_size,
+            latent_dim=50,
+            num_layers=4,
+            num_filters=32,
+            kernel_size=3,
+        )
+
+        critic = DefaultSACCritic(
+            encoder.latent_dim, num_actions, hidden_sizes=[1024, 1024]
+        )
+
+        super().__init__(encoder, critic)
+
+
+class Critic(EncoderCritic):
+    def __init__(self, observation_size: int, num_actions: int, config: SACAE1DConfig):
+
+        ae_config = config.autoencoder_config
+        encoder = Encoder1D(
+            observation_size,
+            latent_dim=ae_config.latent_dim,
+            num_layers=ae_config.num_layers,
+            num_filters=ae_config.num_filters,
+            kernel_size=ae_config.kernel_size,
+        )
+
+        critic_observation_size = encoder.latent_dim
+
+        critic = SACCritic(critic_observation_size, num_actions, config)
+
+        super().__init__(
+            encoder=encoder,
+            critic=critic,
+            add_vector_observation=bool(config.vector_observation),
+        )

--- a/cares_reinforcement_learning/networks/common.py
+++ b/cares_reinforcement_learning/networks/common.py
@@ -353,6 +353,7 @@ class EncoderPolicy(nn.Module):
 
         return self.actor(actor_input)
 
+
 class EncoderPolicy1D(nn.Module):
     def __init__(
         self,
@@ -416,6 +417,7 @@ class EncoderCritic(nn.Module):
             critic_input = torch.cat([state["vector"], critic_input], dim=1)
 
         return self.critic(critic_input, action)
+
 
 class EncoderCritic1D(nn.Module):
     def __init__(

--- a/cares_reinforcement_learning/networks/common.py
+++ b/cares_reinforcement_learning/networks/common.py
@@ -371,11 +371,10 @@ class EncoderPolicy1D(nn.Module):
         self.apply(hlp.weight_init)
 
     def forward(  # type: ignore
-        self, state: torch.Tensor | dict[str, torch.Tensor], detach_encoder: bool = False
+        self, state: torch.Tensor | dict[str, torch.Tensor], detach_encoder: bool = True
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         # Detach at the CNN layer to prevent backpropagation through the encoder
         if isinstance(state, dict):
-            print(f"\n\nState latent shape in Policy: {state['lidar'].shape}, {state['vector'].shape}\n\n")
             state_latent = self.encoder(state["lidar"], detach_cnn=detach_encoder)
         else:
             state_latent = self.encoder(state, detach_cnn=detach_encoder)
@@ -438,11 +437,10 @@ class EncoderCritic1D(nn.Module):
         self,
         state: torch.Tensor | dict[str, torch.Tensor],
         action: torch.Tensor,
-        detach_encoder: bool = False,
+        detach_encoder: bool = True,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         # Detach at the CNN layer to prevent backpropagation through the encoder
         if isinstance(state, dict):
-            print(f"\n\nState latent shape in Critic: {state['lidar'].shape}, {state['vector'].shape}\n\n")
             state_latent = self.encoder(state["lidar"], detach_cnn=detach_encoder)
         else:
             state_latent = self.encoder(state, detach_cnn=detach_encoder)

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -531,6 +531,7 @@ class SACAE1DConfig(SACConfig):
         decoder_optim_kwargs={"lr": 1e-3, "weight_decay": 1e-7},
     )
 
+
 class PERSACConfig(SACConfig):
     algorithm: str = Field("PERSAC", Literal=True)
 

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -473,8 +473,8 @@ class SACAEConfig(SACConfig):
 class SACAE1DConfig(SACConfig):
     algorithm: str = Field("SACAE1D", Literal=True)
 
-    # Vector observation not used
-    vector_observation: Literal[1] = Field(default=0, frozen=True)
+    # Vector observation for linear and angular
+    vector_observation: Literal[1] = Field(default=1, frozen=True)
     batch_size: int = 128
 
     actor_lr: float = 1e-3

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -473,7 +473,8 @@ class SACAEConfig(SACConfig):
 class SACAE1DConfig(SACConfig):
     algorithm: str = Field("SACAE1D", Literal=True)
 
-    vector_observation: Literal[1] = Field(default=1, frozen=True)
+    # Vector observation not used
+    vector_observation: Literal[1] = Field(default=0, frozen=True)
     batch_size: int = 128
 
     actor_lr: float = 1e-3

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -473,7 +473,7 @@ class SACAEConfig(SACConfig):
 class SACAE1DConfig(SACConfig):
     algorithm: str = Field("SACAE1D", Literal=True)
 
-    image_observation: Literal[1] = Field(default=1, frozen=True)
+    vector_observation: Literal[1] = Field(default=1, frozen=True)
     batch_size: int = 128
 
     actor_lr: float = 1e-3

--- a/cares_reinforcement_learning/util/configurations.py
+++ b/cares_reinforcement_learning/util/configurations.py
@@ -470,6 +470,66 @@ class SACAEConfig(SACConfig):
     )
 
 
+class SACAE1DConfig(SACConfig):
+    algorithm: str = Field("SACAE1D", Literal=True)
+
+    image_observation: Literal[1] = Field(default=1, frozen=True)
+    batch_size: int = 128
+
+    actor_lr: float = 1e-3
+    actor_lr_params: dict[str, Any] = Field(
+        default_factory=lambda: {"betas": (0.9, 0.999)}
+    )
+    critic_lr: float = 1e-3
+    critic_lr_params: dict[str, Any] = Field(
+        default_factory=lambda: {"betas": (0.9, 0.999)}
+    )
+    alpha_lr: float = 1e-4
+    alpha_lr_params: dict[str, Any] = Field(
+        default_factory=lambda: {"betas": (0.5, 0.999)}
+    )
+
+    gamma: float = 0.99
+    tau: float = 0.005
+    reward_scale: float = 1.0
+
+    log_std_bounds: list[float] = [-20, 2]
+
+    policy_update_freq: int = 2
+    target_update_freq: int = 2
+
+    actor_config: MLPConfig = MLPConfig(
+        layers=[
+            TrainableLayer(layer_type="Linear", out_features=1024),
+            FunctionLayer(layer_type="ReLU"),
+            TrainableLayer(layer_type="Linear", in_features=1024, out_features=1024),
+            FunctionLayer(layer_type="ReLU"),
+        ]
+    )
+
+    critic_config: MLPConfig = MLPConfig(
+        layers=[
+            TrainableLayer(layer_type="Linear", out_features=1024),
+            FunctionLayer(layer_type="ReLU"),
+            TrainableLayer(layer_type="Linear", in_features=1024, out_features=1024),
+            FunctionLayer(layer_type="ReLU"),
+            TrainableLayer(layer_type="Linear", in_features=1024, out_features=1),
+        ]
+    )
+
+    encoder_tau: float = 0.05
+    decoder_update_freq: int = 1
+
+    autoencoder_config: VanillaAEConfig = VanillaAEConfig(
+        latent_dim=50,
+        num_layers=4,
+        num_filters=32,
+        kernel_size=3,
+        latent_lambda=1e-6,
+        encoder_optim_kwargs={"lr": 1e-3},
+        decoder_optim_kwargs={"lr": 1e-3, "weight_decay": 1e-7},
+    )
+
 class PERSACConfig(SACConfig):
     algorithm: str = Field("PERSAC", Literal=True)
 

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -79,6 +79,7 @@ def image_states_dict_to_tensor(
 
     return {"image": states_images_tensor, "vector": states_vector_tensor}
 
+
 def lidar_state_dict_to_tensor(
     state: dict[str, np.ndarray], device: torch.device
 ) -> dict[str, torch.Tensor]:
@@ -96,14 +97,13 @@ def lidar_states_dict_to_tensor(
     states_lidar = [state["lidar"] for state in states]
     states_vector = [state["vector"] for state in states]
 
-    states_lidar_tensor = (
-        torch.from_numpy(np.asarray(states_lidar)).float().to(device)
-    )
+    states_lidar_tensor = torch.from_numpy(np.asarray(states_lidar)).float().to(device)
     states_vector_tensor = (
         torch.from_numpy(np.asarray(states_vector)).float().to(device)
     )
 
     return {"lidar": states_lidar_tensor, "vector": states_vector_tensor}
+
 
 def set_seed(seed: int) -> None:
     """

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -79,6 +79,31 @@ def image_states_dict_to_tensor(
 
     return {"image": states_images_tensor, "vector": states_vector_tensor}
 
+def lidar_state_dict_to_tensor(
+    state: dict[str, np.ndarray], device: torch.device
+) -> dict[str, torch.Tensor]:
+    vector_tensor = torch.FloatTensor(state["vector"]).to(device)
+    vector_tensor = vector_tensor.unsqueeze(0)
+
+    lidar_tensor = torch.FloatTensor(state["lidar"]).to(device)
+    lidar_tensor = lidar_tensor.unsqueeze(0)
+
+    return {"lidar": lidar_tensor, "vector": vector_tensor}
+
+def lidar_states_dict_to_tensor(
+    states: list[dict[str, np.ndarray]], device: torch.device
+) -> dict[str, torch.Tensor]:
+    states_lidar = [state["lidar"] for state in states]
+    states_vector = [state["vector"] for state in states]
+
+    states_lidar_tensor = (
+        torch.from_numpy(np.asarray(states_lidar)).float().to(device)
+    )
+    states_vector_tensor = (
+        torch.from_numpy(np.asarray(states_vector)).float().to(device)
+    )
+
+    return {"lidar": states_lidar_tensor, "vector": states_vector_tensor}
 
 def set_seed(seed: int) -> None:
     """

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -82,13 +82,11 @@ def image_states_dict_to_tensor(
 def lidar_state_dict_to_tensor(
     state: dict[str, np.ndarray], device: torch.device
 ) -> dict[str, torch.Tensor]:
-    vector_tensor = torch.FloatTensor(state["vector"]).to(device)
+    vector_tensor = torch.FloatTensor(state["vector"]+state["lidar"]).to(device)
     vector_tensor = vector_tensor.unsqueeze(0)
 
-    lidar_tensor = torch.FloatTensor(state["lidar"]).to(device)
-    lidar_tensor = lidar_tensor.unsqueeze(0)
+    return {"lidar": vector_tensor, "vector": vector_tensor}
 
-    return {"lidar": lidar_tensor, "vector": vector_tensor}
 
 def lidar_states_dict_to_tensor(
     states: list[dict[str, np.ndarray]], device: torch.device

--- a/cares_reinforcement_learning/util/helpers.py
+++ b/cares_reinforcement_learning/util/helpers.py
@@ -82,10 +82,12 @@ def image_states_dict_to_tensor(
 def lidar_state_dict_to_tensor(
     state: dict[str, np.ndarray], device: torch.device
 ) -> dict[str, torch.Tensor]:
-    vector_tensor = torch.FloatTensor(state["vector"]+state["lidar"]).to(device)
+    lidar_tensor = torch.FloatTensor(state["lidar"]).to(device)
+    lidar_tensor = lidar_tensor.unsqueeze(0)
+    vector_tensor = torch.FloatTensor(state["vector"]).to(device)
     vector_tensor = vector_tensor.unsqueeze(0)
 
-    return {"lidar": vector_tensor, "vector": vector_tensor}
+    return {"lidar": lidar_tensor, "vector": vector_tensor}
 
 
 def lidar_states_dict_to_tensor(

--- a/cares_reinforcement_learning/util/network_factory.py
+++ b/cares_reinforcement_learning/util/network_factory.py
@@ -211,13 +211,13 @@ def create_SACAE1D(observation_size: int|dict, action_num, config: acf.SACAE1DCo
     ae_config = config.autoencoder_config
     if isinstance(observation_size, dict):
         decoder = Decoder1D(
-            observation_size["lidar"],
-            out_dim=actor.encoder.out_dim,
-            latent_dim=ae_config.latent_dim,
-            num_layers=ae_config.num_layers,
-            num_filters=ae_config.num_filters,
-            kernel_size=ae_config.kernel_size,
-        )
+        observation_size["lidar"],
+        out_dim=actor.encoder.out_dim,
+        latent_dim=ae_config.latent_dim,
+        num_layers=ae_config.num_layers,
+        num_filters=ae_config.num_filters,
+        kernel_size=ae_config.kernel_size,
+    )
     else:
         decoder = Decoder1D(
             observation_size,

--- a/cares_reinforcement_learning/util/network_factory.py
+++ b/cares_reinforcement_learning/util/network_factory.py
@@ -200,7 +200,7 @@ def create_SACAE(observation_size, action_num, config: acf.SACAEConfig):
     )
     return agent
 
-def create_SACAE1D(observation_size, action_num, config: acf.SACAE1DConfig):
+def create_SACAE1D(observation_size: int|dict, action_num, config: acf.SACAE1DConfig):
     from cares_reinforcement_learning.algorithm.policy.SACAE1D import SACAE1D
     from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder1D
     from cares_reinforcement_learning.networks.SACAE1D import Actor, Critic
@@ -209,14 +209,24 @@ def create_SACAE1D(observation_size, action_num, config: acf.SACAE1DConfig):
     critic = Critic(observation_size, action_num, config=config)
 
     ae_config = config.autoencoder_config
-    decoder = Decoder1D(
-        observation_size,
-        out_dim=actor.encoder.out_dim,
-        latent_dim=ae_config.latent_dim,
-        num_layers=ae_config.num_layers,
-        num_filters=ae_config.num_filters,
-        kernel_size=ae_config.kernel_size,
-    )
+    if isinstance(observation_size, dict):
+        decoder = Decoder1D(
+            observation_size["lidar"],
+            out_dim=actor.encoder.out_dim,
+            latent_dim=ae_config.latent_dim,
+            num_layers=ae_config.num_layers,
+            num_filters=ae_config.num_filters,
+            kernel_size=ae_config.kernel_size,
+        )
+    else:
+        decoder = Decoder1D(
+            observation_size,
+            out_dim=actor.encoder.out_dim,
+            latent_dim=ae_config.latent_dim,
+            num_layers=ae_config.num_layers,
+            num_filters=ae_config.num_filters,
+            kernel_size=ae_config.kernel_size,
+        )
 
     device = hlp.get_device()
     agent = SACAE1D(

--- a/cares_reinforcement_learning/util/network_factory.py
+++ b/cares_reinforcement_learning/util/network_factory.py
@@ -183,7 +183,8 @@ def create_SACAE(observation_size, action_num, config: acf.SACAEConfig):
     )
     return agent
 
-def create_SACAE1D(observation_size: int|dict, action_num, config: acf.SACAE1DConfig):
+
+def create_SACAE1D(observation_size: int | dict, action_num, config: acf.SACAE1DConfig):
     from cares_reinforcement_learning.algorithm.policy.SACAE1D import SACAE1D
     from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder1D
     from cares_reinforcement_learning.networks.SACAE1D import Actor, Critic
@@ -194,13 +195,13 @@ def create_SACAE1D(observation_size: int|dict, action_num, config: acf.SACAE1DCo
     ae_config = config.autoencoder_config
     if isinstance(observation_size, dict):
         decoder = Decoder1D(
-        observation_size["lidar"],
-        out_dim=actor.encoder.out_dim,
-        latent_dim=ae_config.latent_dim,
-        num_layers=ae_config.num_layers,
-        num_filters=ae_config.num_filters,
-        kernel_size=ae_config.kernel_size,
-    )
+            observation_size["lidar"],
+            out_dim=actor.encoder.out_dim,
+            latent_dim=ae_config.latent_dim,
+            num_layers=ae_config.num_layers,
+            num_filters=ae_config.num_filters,
+            kernel_size=ae_config.kernel_size,
+        )
     else:
         decoder = Decoder1D(
             observation_size,

--- a/cares_reinforcement_learning/util/network_factory.py
+++ b/cares_reinforcement_learning/util/network_factory.py
@@ -200,6 +200,34 @@ def create_SACAE(observation_size, action_num, config: acf.SACAEConfig):
     )
     return agent
 
+def create_SACAE1D(observation_size, action_num, config: acf.SACAE1DConfig):
+    from cares_reinforcement_learning.algorithm.policy.SACAE1D import SACAE1D
+    from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder1D
+    from cares_reinforcement_learning.networks.SACAE1D import Actor, Critic
+
+    actor = Actor(observation_size, action_num, config=config)
+    critic = Critic(observation_size, action_num, config=config)
+
+    ae_config = config.autoencoder_config
+    decoder = Decoder1D(
+        observation_size,
+        out_dim=actor.encoder.out_dim,
+        latent_dim=ae_config.latent_dim,
+        num_layers=ae_config.num_layers,
+        num_filters=ae_config.num_filters,
+        kernel_size=ae_config.kernel_size,
+    )
+
+    device = hlp.get_device()
+    agent = SACAE1D(
+        actor_network=actor,
+        critic_network=critic,
+        decoder_network=decoder,
+        config=config,
+        device=device,
+    )
+    return agent
+
 
 def create_PERSAC(observation_size, action_num, config: acf.PERSACConfig):
     from cares_reinforcement_learning.algorithm.policy import PERSAC


### PR DESCRIPTION
Modified original 2D SACAE to accept 1D inputs. The state dictionary keys are changed to "lidar" and "vector" instead of "image" and "vector". Alternatively, the state can be a single list but `detach_cnn`, `detach_output` needs to be set to `False` in `vanilla_autoencoder.py` and `vector_observation` needs to be set to 0 in `configurations.py`.