### PR TITLE
Action Sampler passed into Algorithms

### DIFF
--- a/cares_reinforcement_learning/algorithm/algorithm.py
+++ b/cares_reinforcement_learning/algorithm/algorithm.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, Generic, Literal, TypeVar
 
 import numpy as np
 import torch
 
 import cares_reinforcement_learning.util.helpers as hlp
+from cares_reinforcement_learning.algorithm.configurations import AlgorithmConfig
 from cares_reinforcement_learning.memory.memory_buffer import (
     MARLMemoryBuffer,
     Memory,
@@ -17,7 +19,6 @@ from cares_reinforcement_learning.types.observation import (
     Observation,
     SARLObservation,
 )
-from cares_reinforcement_learning.algorithm.configurations import AlgorithmConfig
 
 # Type variable for observation types (SARL or MARL)
 ObsType = TypeVar("ObsType", bound=Observation)
@@ -29,6 +30,7 @@ class Algorithm(ABC, Generic[ObsType, ActType, MemType]):
         self,
         policy_type: Literal["value", "policy", "discrete_policy", "mbrl", "usd"],
         config: AlgorithmConfig,
+        action_sampler: Callable[[], ActType],
         device: torch.device,
     ):
         self.policy_type: Literal[
@@ -36,6 +38,8 @@ class Algorithm(ABC, Generic[ObsType, ActType, MemType]):
         ] = policy_type
 
         self.config = config
+
+        self.action_sampler: Callable[[], ActType] = action_sampler
 
         self.gamma = config.gamma
 

--- a/cares_reinforcement_learning/algorithm/algorithm_factory.py
+++ b/cares_reinforcement_learning/algorithm/algorithm_factory.py
@@ -6,6 +6,7 @@ with their corresponding network architectures.
 import inspect
 import logging
 import sys
+from collections.abc import Callable
 
 import numpy as np
 
@@ -20,40 +21,54 @@ import cares_reinforcement_learning.util.helpers as hlp
 ###################################
 #         DQN Algorithms          #
 ###################################
-def create_DQN(observation_size, action_num, config: acf.DQNConfig):
+def create_DQN(
+    observation_size, action_num, config: acf.DQNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import DQN
     from cares_reinforcement_learning.networks.DQN import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = DQN(network=network, config=config, device=device)
+    agent = DQN(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_PERDQN(observation_size, action_num, config: acf.PERDQNConfig):
+def create_PERDQN(
+    observation_size, action_num, config: acf.PERDQNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import PERDQN
     from cares_reinforcement_learning.networks.PERDQN import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = PERDQN(network=network, config=config, device=device)
+    agent = PERDQN(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_DuelingDQN(observation_size, action_num, config: acf.DuelingDQNConfig):
+def create_DuelingDQN(
+    observation_size, action_num, config: acf.DuelingDQNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import DuelingDQN
     from cares_reinforcement_learning.networks.DuelingDQN import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = DuelingDQN(network=network, config=config, device=device)
+    agent = DuelingDQN(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_DoubleDQN(observation_size, action_num, config: acf.DoubleDQNConfig):
+def create_DoubleDQN(
+    observation_size, action_num, config: acf.DoubleDQNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import DoubleDQN
     from cares_reinforcement_learning.networks.DoubleDQN import Network
 
@@ -63,52 +78,69 @@ def create_DoubleDQN(observation_size, action_num, config: acf.DoubleDQNConfig):
     agent = DoubleDQN(
         network=network,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_NoisyNet(observation_size, action_num, config: acf.NoisyNetConfig):
+def create_NoisyNet(
+    observation_size, action_num, config: acf.NoisyNetConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import NoisyNet
     from cares_reinforcement_learning.networks.NoisyNet import Network
 
     network = Network(observation_size["vector"], action_num, config)
 
     device = hlp.get_device()
-    agent = NoisyNet(network=network, config=config, device=device)
+    agent = NoisyNet(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_C51(observation_size, action_num, config: acf.C51Config):
+def create_C51(
+    observation_size, action_num, config: acf.C51Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import C51
     from cares_reinforcement_learning.networks.C51 import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = C51(network=network, config=config, device=device)
+    agent = C51(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_QRDQN(observation_size, action_num, config: acf.QRDQNConfig):
+def create_QRDQN(
+    observation_size, action_num, config: acf.QRDQNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import QRDQN
     from cares_reinforcement_learning.networks.QRDQN import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = QRDQN(network=network, config=config, device=device)
+    agent = QRDQN(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
-def create_Rainbow(observation_size, action_num, config: acf.RainbowConfig):
+def create_Rainbow(
+    observation_size, action_num, config: acf.RainbowConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.value import Rainbow
     from cares_reinforcement_learning.networks.Rainbow import Network
 
     network = Network(observation_size["vector"], action_num, config=config)
 
     device = hlp.get_device()
-    agent = Rainbow(network=network, config=config, device=device)
+    agent = Rainbow(
+        network=network, config=config, action_sampler=action_sampler, device=device
+    )
     return agent
 
 
@@ -117,7 +149,9 @@ def create_Rainbow(observation_size, action_num, config: acf.RainbowConfig):
 ###################################
 
 
-def create_PPO(observation_size, action_num, config: acf.PPOConfig):
+def create_PPO(
+    observation_size, action_num, config: acf.PPOConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import PPO
     from cares_reinforcement_learning.networks.PPO import Actor, Critic
 
@@ -129,6 +163,7 @@ def create_PPO(observation_size, action_num, config: acf.PPOConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
@@ -139,7 +174,9 @@ def create_PPO(observation_size, action_num, config: acf.PPOConfig):
 ###################################
 
 
-def create_SAC(observation_size, action_num, config: acf.SACConfig):
+def create_SAC(
+    observation_size, action_num, config: acf.SACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import SAC
     from cares_reinforcement_learning.networks.SAC import Actor, Critic
 
@@ -151,12 +188,15 @@ def create_SAC(observation_size, action_num, config: acf.SACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_SACAE(observation_size, action_num, config: acf.SACAEConfig):
+def create_SACAE(
+    observation_size, action_num, config: acf.SACAEConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import SACAE
     from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
     from cares_reinforcement_learning.networks.SACAE import Actor, Critic
@@ -180,12 +220,15 @@ def create_SACAE(observation_size, action_num, config: acf.SACAEConfig):
         critic_network=critic,
         decoder_network=decoder,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_PERSAC(observation_size, action_num, config: acf.PERSACConfig):
+def create_PERSAC(
+    observation_size, action_num, config: acf.PERSACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import PERSAC
     from cares_reinforcement_learning.networks.PERSAC import Actor, Critic
 
@@ -197,12 +240,15 @@ def create_PERSAC(observation_size, action_num, config: acf.PERSACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_REDQ(observation_size, action_num, config: acf.REDQConfig):
+def create_REDQ(
+    observation_size, action_num, config: acf.REDQConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import REDQ
     from cares_reinforcement_learning.networks.REDQ import Actor, Critic
 
@@ -214,12 +260,15 @@ def create_REDQ(observation_size, action_num, config: acf.REDQConfig):
         actor_network=actor,
         ensemble_critic=ensemble_critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_TQC(observation_size, action_num, config: acf.TQCConfig):
+def create_TQC(
+    observation_size, action_num, config: acf.TQCConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import TQC
     from cares_reinforcement_learning.networks.TQC import Actor, Critic
 
@@ -231,12 +280,15 @@ def create_TQC(observation_size, action_num, config: acf.TQCConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_LAPSAC(observation_size, action_num, config: acf.LAPSACConfig):
+def create_LAPSAC(
+    observation_size, action_num, config: acf.LAPSACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import LAPSAC
     from cares_reinforcement_learning.networks.LAPSAC import Actor, Critic
 
@@ -248,12 +300,15 @@ def create_LAPSAC(observation_size, action_num, config: acf.LAPSACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_LA3PSAC(observation_size, action_num, config: acf.LA3PSACConfig):
+def create_LA3PSAC(
+    observation_size, action_num, config: acf.LA3PSACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import LA3PSAC
     from cares_reinforcement_learning.networks.LA3PSAC import Actor, Critic
 
@@ -265,12 +320,15 @@ def create_LA3PSAC(observation_size, action_num, config: acf.LA3PSACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_MAPERSAC(observation_size, action_num, config: acf.MAPERSACConfig):
+def create_MAPERSAC(
+    observation_size, action_num, config: acf.MAPERSACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import MAPERSAC
     from cares_reinforcement_learning.networks.MAPERSAC import Actor, Critic
 
@@ -282,12 +340,15 @@ def create_MAPERSAC(observation_size, action_num, config: acf.MAPERSACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_RDSAC(observation_size, action_num, config: acf.RDSACConfig):
+def create_RDSAC(
+    observation_size, action_num, config: acf.RDSACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import RDSAC
     from cares_reinforcement_learning.networks.RDSAC import Actor, Critic
 
@@ -299,12 +360,15 @@ def create_RDSAC(observation_size, action_num, config: acf.RDSACConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_DroQ(observation_size, action_num, config: acf.DroQConfig):
+def create_DroQ(
+    observation_size, action_num, config: acf.DroQConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import DroQ
     from cares_reinforcement_learning.networks.DroQ import Actor, Critic
 
@@ -316,12 +380,15 @@ def create_DroQ(observation_size, action_num, config: acf.DroQConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_CrossQ(observation_size, action_num, config: acf.CrossQConfig):
+def create_CrossQ(
+    observation_size, action_num, config: acf.CrossQConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import CrossQ
     from cares_reinforcement_learning.networks.CrossQ import Actor, Critic
 
@@ -333,12 +400,15 @@ def create_CrossQ(observation_size, action_num, config: acf.CrossQConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_SDAR(observation_size, action_num, config: acf.SDARConfig):
+def create_SDAR(
+    observation_size, action_num, config: acf.SDARConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import SDAR
     from cares_reinforcement_learning.networks.SDAR import Actor, Critic
 
@@ -350,12 +420,15 @@ def create_SDAR(observation_size, action_num, config: acf.SDARConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_SACD(observation_size, action_num, config: acf.SACDConfig):
+def create_SACD(
+    observation_size, action_num, config: acf.SACDConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import SACD
     from cares_reinforcement_learning.networks.SACD import Actor, Critic
 
@@ -367,12 +440,15 @@ def create_SACD(observation_size, action_num, config: acf.SACDConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_DIAYN(observation_size, action_num, config: acf.DIAYNConfig):
+def create_DIAYN(
+    observation_size, action_num, config: acf.DIAYNConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.usd import DIAYN
     from cares_reinforcement_learning.networks.DIAYN import Discriminator
 
@@ -389,12 +465,15 @@ def create_DIAYN(observation_size, action_num, config: acf.DIAYNConfig):
         skills_agent=agent,
         discriminator_network=discriminator,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_DADS(observation_size, action_num, config: acf.DADSConfig):
+def create_DADS(
+    observation_size, action_num, config: acf.DADSConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.usd import DADS
     from cares_reinforcement_learning.networks.DADS import SkillDynamicsModel
 
@@ -407,6 +486,7 @@ def create_DADS(observation_size, action_num, config: acf.DADSConfig):
     discriminator = SkillDynamicsModel(
         observation_size=observation_size["vector"],
         config=config,
+        action_sampler=action_sampler,
     )
 
     device = hlp.get_device()
@@ -414,6 +494,7 @@ def create_DADS(observation_size, action_num, config: acf.DADSConfig):
         skills_agent=agent,
         discriminator_network=discriminator,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
@@ -424,7 +505,9 @@ def create_DADS(observation_size, action_num, config: acf.DADSConfig):
 ###################################
 
 
-def create_DDPG(observation_size, action_num, config: acf.DDPGConfig):
+def create_DDPG(
+    observation_size, action_num, config: acf.DDPGConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import DDPG
     from cares_reinforcement_learning.networks.DDPG import Actor, Critic
 
@@ -436,12 +519,15 @@ def create_DDPG(observation_size, action_num, config: acf.DDPGConfig):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_TD3(observation_size, action_num, config: acf.TD3Config):
+def create_TD3(
+    observation_size, action_num, config: acf.TD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import TD3
     from cares_reinforcement_learning.networks.TD3 import Actor, Critic
 
@@ -453,12 +539,15 @@ def create_TD3(observation_size, action_num, config: acf.TD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_TD3AE(observation_size, action_num, config: acf.TD3AEConfig):
+def create_TD3AE(
+    observation_size, action_num, config: acf.TD3AEConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import TD3AE
     from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
     from cares_reinforcement_learning.networks.TD3AE import Actor, Critic
@@ -482,12 +571,15 @@ def create_TD3AE(observation_size, action_num, config: acf.TD3AEConfig):
         critic_network=critic,
         decoder_network=decoder,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_NaSATD3(observation_size, action_num, config: acf.NaSATD3Config):
+def create_NaSATD3(
+    observation_size, action_num, config: acf.NaSATD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import NaSATD3
     from cares_reinforcement_learning.networks.NaSATD3 import Actor, Critic
 
@@ -499,12 +591,15 @@ def create_NaSATD3(observation_size, action_num, config: acf.NaSATD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_PERTD3(observation_size, action_num, config: acf.PERTD3Config):
+def create_PERTD3(
+    observation_size, action_num, config: acf.PERTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import PERTD3
     from cares_reinforcement_learning.networks.PERTD3 import Actor, Critic
 
@@ -516,12 +611,15 @@ def create_PERTD3(observation_size, action_num, config: acf.PERTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_LAPTD3(observation_size, action_num, config: acf.LAPTD3Config):
+def create_LAPTD3(
+    observation_size, action_num, config: acf.LAPTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import LAPTD3
     from cares_reinforcement_learning.networks.LAPTD3 import Actor, Critic
 
@@ -533,12 +631,15 @@ def create_LAPTD3(observation_size, action_num, config: acf.LAPTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_PALTD3(observation_size, action_num, config: acf.PALTD3Config):
+def create_PALTD3(
+    observation_size, action_num, config: acf.PALTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import PALTD3
     from cares_reinforcement_learning.networks.PALTD3 import Actor, Critic
 
@@ -550,12 +651,15 @@ def create_PALTD3(observation_size, action_num, config: acf.PALTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_LA3PTD3(observation_size, action_num, config: acf.LA3PTD3Config):
+def create_LA3PTD3(
+    observation_size, action_num, config: acf.LA3PTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import LA3PTD3
     from cares_reinforcement_learning.networks.LA3PTD3 import Actor, Critic
 
@@ -567,12 +671,15 @@ def create_LA3PTD3(observation_size, action_num, config: acf.LA3PTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_MAPERTD3(observation_size, action_num, config: acf.MAPERTD3Config):
+def create_MAPERTD3(
+    observation_size, action_num, config: acf.MAPERTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import MAPERTD3
     from cares_reinforcement_learning.networks.MAPERTD3 import Actor, Critic
 
@@ -584,12 +691,15 @@ def create_MAPERTD3(observation_size, action_num, config: acf.MAPERTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_RDTD3(observation_size, action_num, config: acf.RDTD3Config):
+def create_RDTD3(
+    observation_size, action_num, config: acf.RDTD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import RDTD3
     from cares_reinforcement_learning.networks.RDTD3 import Actor, Critic
 
@@ -601,12 +711,15 @@ def create_RDTD3(observation_size, action_num, config: acf.RDTD3Config):
         actor_network=actor,
         critic_network=critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return agent
 
 
-def create_CTD4(observation_size, action_num, config: acf.CTD4Config):
+def create_CTD4(
+    observation_size, action_num, config: acf.CTD4Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import CTD4
     from cares_reinforcement_learning.networks.CTD4 import Actor, Critic
 
@@ -619,13 +732,16 @@ def create_CTD4(observation_size, action_num, config: acf.CTD4Config):
         actor_network=actor,
         ensemble_critic=ensemble_critic,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
     return agent
 
 
-def create_TD7(observation_size, action_num, config: acf.TD7Config):
+def create_TD7(
+    observation_size, action_num, config: acf.TD7Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.policy import TD7
     from cares_reinforcement_learning.networks.TD7 import Actor, Critic, Encoder
 
@@ -640,6 +756,7 @@ def create_TD7(observation_size, action_num, config: acf.TD7Config):
         critic_network=critic,
         encoder_network=encoder,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
@@ -832,6 +949,7 @@ def _build_learning_units(
     observation_size,
     action_num: int,
     config,
+    action_sampler: Callable,
     device,
     Algorithm,
     Actor,
@@ -931,13 +1049,16 @@ def _build_learning_units(
             actor_network=actor,
             critic_network=critic,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 
     return learning_units
 
 
-def create_MADDPG(observation_size, action_num, config: acf.MADDPGConfig):
+def create_MADDPG(
+    observation_size, action_num, config: acf.MADDPGConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import MADDPG
     from cares_reinforcement_learning.algorithm.policy.DDPG import DDPG
     from cares_reinforcement_learning.networks.MADDPG import Actor, Critic
@@ -964,6 +1085,7 @@ def create_MADDPG(observation_size, action_num, config: acf.MADDPGConfig):
         observation_size=observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
         device=device,
         Algorithm=DDPG,
         Actor=Actor,
@@ -979,11 +1101,14 @@ def create_MADDPG(observation_size, action_num, config: acf.MADDPGConfig):
         agent_id_to_critic_id=agent_id_to_critic_id,
         critic_id_to_agent_ids=critic_id_to_agent_ids,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
 
-def create_M3DDPG(observation_size, action_num, config: acf.M3DDPGConfig):
+def create_M3DDPG(
+    observation_size, action_num, config: acf.M3DDPGConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import M3DDPG
     from cares_reinforcement_learning.algorithm.policy.DDPG import DDPG
     from cares_reinforcement_learning.networks.M3DDPG import Actor, Critic
@@ -1010,6 +1135,7 @@ def create_M3DDPG(observation_size, action_num, config: acf.M3DDPGConfig):
         observation_size=observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
         device=device,
         Algorithm=DDPG,
         Actor=Actor,
@@ -1025,11 +1151,14 @@ def create_M3DDPG(observation_size, action_num, config: acf.M3DDPGConfig):
         agent_id_to_critic_id=agent_id_to_critic_id,
         critic_id_to_agent_ids=critic_id_to_agent_ids,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
 
-def create_MATD3(observation_size, action_num, config: acf.MATD3Config):
+def create_MATD3(
+    observation_size, action_num, config: acf.MATD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import MATD3
     from cares_reinforcement_learning.algorithm.policy.TD3 import TD3
     from cares_reinforcement_learning.networks.MATD3 import Actor, Critic
@@ -1056,6 +1185,7 @@ def create_MATD3(observation_size, action_num, config: acf.MATD3Config):
         observation_size=observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
         device=device,
         Algorithm=TD3,
         Actor=Actor,
@@ -1071,11 +1201,14 @@ def create_MATD3(observation_size, action_num, config: acf.MATD3Config):
         agent_id_to_critic_id=agent_id_to_critic_id,
         critic_id_to_agent_ids=critic_id_to_agent_ids,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
 
-def create_MASAC(observation_size, action_num, config: acf.MASACConfig):
+def create_MASAC(
+    observation_size, action_num, config: acf.MASACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl.MASAC import MASAC
     from cares_reinforcement_learning.algorithm.policy.SAC import SAC
     from cares_reinforcement_learning.networks.MASAC import Actor, Critic
@@ -1102,6 +1235,7 @@ def create_MASAC(observation_size, action_num, config: acf.MASACConfig):
         observation_size=observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
         device=device,
         Algorithm=SAC,
         Actor=Actor,
@@ -1117,11 +1251,14 @@ def create_MASAC(observation_size, action_num, config: acf.MASACConfig):
         agent_id_to_critic_id=agent_id_to_critic_id,
         critic_id_to_agent_ids=critic_id_to_agent_ids,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
 
-def create_MAPPO(observation_size, action_num, config: acf.MAPPOConfig):
+def create_MAPPO(
+    observation_size, action_num, config: acf.MAPPOConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import MAPPO
     from cares_reinforcement_learning.algorithm.policy.PPO import PPO
     from cares_reinforcement_learning.networks.MAPPO import Actor, Critic
@@ -1148,6 +1285,7 @@ def create_MAPPO(observation_size, action_num, config: acf.MAPPOConfig):
         observation_size=observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
         device=device,
         Algorithm=PPO,
         Actor=Actor,
@@ -1164,15 +1302,18 @@ def create_MAPPO(observation_size, action_num, config: acf.MAPPOConfig):
         agent_id_to_critic_id=agent_id_to_critic_id,
         critic_id_to_agent_ids=critic_id_to_agent_ids,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
 
 
-def create_QMIX(observation_size, action_num, config: acf.QMIXConfig):
+def create_QMIX(
+    observation_size, action_num, config: acf.QMIXConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import QMIX
     from cares_reinforcement_learning.networks.QMIX import (
-        SharedMultiAgentNetwork,
         QMixer,
+        SharedMultiAgentNetwork,
     )
 
     network = SharedMultiAgentNetwork(
@@ -1184,12 +1325,22 @@ def create_QMIX(observation_size, action_num, config: acf.QMIXConfig):
     mixer = QMixer(observation_size=observation_size, config=config)
 
     device = hlp.get_device()
-    agent = QMIX(network=network, mixer=mixer, config=config, device=device)
+    agent = QMIX(
+        network=network,
+        mixer=mixer,
+        config=config,
+        action_sampler=action_sampler,
+        device=device,
+    )
     return agent
 
 
 def _create_independant_agents(
-    observation_size, action_num, create_network, config: acf.AlgorithmConfig
+    observation_size,
+    action_num,
+    create_network,
+    action_sampler,
+    config: acf.AlgorithmConfig,
 ):
     obs_shapes = observation_size["obs"]  # dict[str → obs_dim]
 
@@ -1201,6 +1352,7 @@ def _create_independant_agents(
             observation_size=agent_obs,
             action_num=action_num,
             config=config,
+            action_sampler=action_sampler,
         )
         agents[agent_name] = network
 
@@ -1211,6 +1363,7 @@ def _create_imarl_learning_units(
     observation_size,
     action_num,
     create_network,
+    action_sampler,
     config,
 ) -> tuple[
     dict[str, object],
@@ -1246,6 +1399,7 @@ def _create_imarl_learning_units(
             observation_size,
             action_num,
             create_network,
+            action_sampler,
             config,
         )
         agent_id_to_learning_unit_id = {
@@ -1290,6 +1444,7 @@ def _create_imarl_learning_units(
         observation_size=shared_observation_size,
         action_num=action_num,
         config=config,
+        action_sampler=action_sampler,
     )
 
     learning_units = {"shared": shared_learning_unit}
@@ -1304,7 +1459,9 @@ def _create_imarl_learning_units(
     )
 
 
-def create_IDDPG(observation_size, action_num, config: acf.IDDPGConfig):
+def create_IDDPG(
+    observation_size, action_num, config: acf.IDDPGConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import IDDPG
 
     device = hlp.get_device()
@@ -1315,7 +1472,9 @@ def create_IDDPG(observation_size, action_num, config: acf.IDDPGConfig):
         agent_identity_vectors,
         team_identity_vectors,
         agent_id_to_team_id,
-    ) = _create_imarl_learning_units(observation_size, action_num, create_DDPG, config)
+    ) = _create_imarl_learning_units(
+        observation_size, action_num, create_DDPG, action_sampler, config
+    )
 
     iddpg_agent = IDDPG(
         learning_units=learning_units,
@@ -1325,12 +1484,15 @@ def create_IDDPG(observation_size, action_num, config: acf.IDDPGConfig):
         team_identity_vectors=team_identity_vectors,
         agent_id_to_team_id=agent_id_to_team_id,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return iddpg_agent
 
 
-def create_ITD3(observation_size, action_num, config: acf.ITD3Config):
+def create_ITD3(
+    observation_size, action_num, config: acf.ITD3Config, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import ITD3
 
     device = hlp.get_device()
@@ -1341,7 +1503,9 @@ def create_ITD3(observation_size, action_num, config: acf.ITD3Config):
         agent_identity_vectors,
         team_identity_vectors,
         agent_id_to_team_id,
-    ) = _create_imarl_learning_units(observation_size, action_num, create_TD3, config)
+    ) = _create_imarl_learning_units(
+        observation_size, action_num, create_TD3, action_sampler, config
+    )
 
     itd3_agent = ITD3(
         learning_units=learning_units,
@@ -1351,12 +1515,15 @@ def create_ITD3(observation_size, action_num, config: acf.ITD3Config):
         team_identity_vectors=team_identity_vectors,
         agent_id_to_team_id=agent_id_to_team_id,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return itd3_agent
 
 
-def create_ISAC(observation_size, action_num, config: acf.ISACConfig):
+def create_ISAC(
+    observation_size, action_num, config: acf.ISACConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import ISAC
 
     device = hlp.get_device()
@@ -1367,7 +1534,9 @@ def create_ISAC(observation_size, action_num, config: acf.ISACConfig):
         agent_identity_vectors,
         team_identity_vectors,
         agent_id_to_team_id,
-    ) = _create_imarl_learning_units(observation_size, action_num, create_SAC, config)
+    ) = _create_imarl_learning_units(
+        observation_size, action_num, create_SAC, action_sampler, config
+    )
 
     isac_agent = ISAC(
         learning_units=learning_units,
@@ -1377,12 +1546,15 @@ def create_ISAC(observation_size, action_num, config: acf.ISACConfig):
         team_identity_vectors=team_identity_vectors,
         agent_id_to_team_id=agent_id_to_team_id,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return isac_agent
 
 
-def create_IPPO(observation_size, action_num, config: acf.IPPOConfig):
+def create_IPPO(
+    observation_size, action_num, config: acf.IPPOConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import IPPO
 
     device = hlp.get_device()
@@ -1393,7 +1565,9 @@ def create_IPPO(observation_size, action_num, config: acf.IPPOConfig):
         agent_identity_vectors,
         team_identity_vectors,
         agent_id_to_team_id,
-    ) = _create_imarl_learning_units(observation_size, action_num, create_PPO, config)
+    ) = _create_imarl_learning_units(
+        observation_size, action_num, create_PPO, action_sampler, config
+    )
 
     ippo_agent = IPPO(
         learning_units=learning_units,
@@ -1403,12 +1577,15 @@ def create_IPPO(observation_size, action_num, config: acf.IPPOConfig):
         team_identity_vectors=team_identity_vectors,
         agent_id_to_team_id=agent_id_to_team_id,
         config=config,
+        action_sampler=action_sampler,
         device=device,
     )
     return ippo_agent
 
 
-def create_CrossMARL(observation_size, action_num, config: acf.CrossMARLConfig):
+def create_CrossMARL(
+    observation_size, action_num, config: acf.CrossMARLConfig, action_sampler: Callable
+):
     from cares_reinforcement_learning.algorithm.marl import CrossMARL
 
     device = hlp.get_device()
@@ -1443,11 +1620,16 @@ def create_CrossMARL(observation_size, action_num, config: acf.CrossMARLConfig):
             observation_size=agent_obs,
             action_num=action_num,
             config=config.agents_config[team_name],
+            action_sampler=action_sampler,
         )
         agents[team_name] = agent
 
     multimarl_agent = CrossMARL(
-        agent_networks=agents, env_teams=env_teams, config=config, device=device
+        agent_networks=agents,
+        env_teams=env_teams,
+        config=config,
+        action_sampler=action_sampler,
+        device=device,
     )
     return multimarl_agent
 
@@ -1478,6 +1660,7 @@ class AlgorithmFactory:
         observation_size,
         action_num: int,
         config: acf.AlgorithmConfig,
+        action_sampler: Callable,
     ):
         algorithm = config.algorithm
 
@@ -1485,7 +1668,7 @@ class AlgorithmFactory:
         for name, obj in inspect.getmembers(sys.modules[__name__]):
             if inspect.isfunction(obj):
                 if name == f"create_{algorithm}":
-                    agent = obj(observation_size, action_num, config)
+                    agent = obj(observation_size, action_num, config, action_sampler)
 
         if agent is None:
             logging.warning(f"Unknown {algorithm} algorithm.")

--- a/cares_reinforcement_learning/algorithm/algorithm_factory.py
+++ b/cares_reinforcement_learning/algorithm/algorithm_factory.py
@@ -456,7 +456,9 @@ def create_DIAYN(
         "vector": observation_size["vector"] + config.num_skills,
     }
 
-    agent = create_SAC(sac_observation_size, action_num, config=config)
+    agent = create_SAC(
+        sac_observation_size, action_num, config=config, action_sampler=action_sampler
+    )
 
     discriminator = Discriminator(observation_size["vector"], config=config)
 
@@ -481,12 +483,13 @@ def create_DADS(
         "vector": observation_size["vector"] + config.z_dim,
     }
 
-    agent = create_SAC(sac_observation_size, action_num, config=config)
+    agent = create_SAC(
+        sac_observation_size, action_num, config=config, action_sampler=action_sampler
+    )
 
     discriminator = SkillDynamicsModel(
         observation_size=observation_size["vector"],
         config=config,
-        action_sampler=action_sampler,
     )
 
     device = hlp.get_device()

--- a/cares_reinforcement_learning/algorithm/marl/CrossMARL.py
+++ b/cares_reinforcement_learning/algorithm/marl/CrossMARL.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -21,9 +22,15 @@ class CrossMARL(MARLAlgorithm[dict[str, np.ndarray]]):
         agent_networks: dict[str, MARLAlgorithm[dict[str, np.ndarray]]],
         env_teams: dict[str, list[str]],
         config: CrossMARLConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.agent_networks = agent_networks
 

--- a/cares_reinforcement_learning/algorithm/marl/IMARL.py
+++ b/cares_reinforcement_learning/algorithm/marl/IMARL.py
@@ -112,6 +112,7 @@ Summary:
 import logging
 import os
 from abc import abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
 
@@ -119,9 +120,9 @@ import numpy as np
 import numpy.typing as npt
 import torch
 
+import cares_reinforcement_learning.algorithm.configurations as cfg
 import cares_reinforcement_learning.algorithm.policy as pol
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.algorithm.configurations as cfg
 from cares_reinforcement_learning.algorithm.algorithm import (
     MARLAlgorithm,
     SARLAlgorithm,
@@ -162,9 +163,15 @@ class IMARL(MARLAlgorithm[dict[str, np.ndarray]], Generic[AgentType]):
         team_identity_vectors: dict[str, npt.NDArray[np.float32]],
         agent_id_to_team_id: dict[str, str],
         config: IMARLConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.learning_units = learning_units
         self.agent_id_to_learning_unit_id = agent_id_to_learning_unit_id
@@ -526,6 +533,7 @@ class IDDPG(IMARL[pol.DDPG]):
         team_identity_vectors: dict[str, npt.NDArray[np.float32]],
         agent_id_to_team_id: dict[str, str],
         config: cfg.IDDPGConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
         super().__init__(
@@ -536,6 +544,7 @@ class IDDPG(IMARL[pol.DDPG]):
             team_identity_vectors=team_identity_vectors,
             agent_id_to_team_id=agent_id_to_team_id,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 
@@ -572,6 +581,7 @@ class ITD3(IMARL[pol.TD3]):
         team_identity_vectors: dict[str, npt.NDArray[np.float32]],
         agent_id_to_team_id: dict[str, str],
         config: cfg.ITD3Config,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
         super().__init__(
@@ -582,6 +592,7 @@ class ITD3(IMARL[pol.TD3]):
             team_identity_vectors=team_identity_vectors,
             agent_id_to_team_id=agent_id_to_team_id,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 
@@ -621,6 +632,7 @@ class ISAC(IMARL[pol.SAC]):
         team_identity_vectors: dict[str, npt.NDArray[np.float32]],
         agent_id_to_team_id: dict[str, str],
         config: cfg.ISACConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
         super().__init__(
@@ -631,6 +643,7 @@ class ISAC(IMARL[pol.SAC]):
             team_identity_vectors=team_identity_vectors,
             agent_id_to_team_id=agent_id_to_team_id,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 
@@ -668,6 +681,7 @@ class IPPO(IMARL[pol.PPO]):
         team_identity_vectors: dict[str, npt.NDArray[np.float32]],
         agent_id_to_team_id: dict[str, str],
         config: cfg.IPPOConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
         super().__init__(
@@ -678,6 +692,7 @@ class IPPO(IMARL[pol.PPO]):
             team_identity_vectors=team_identity_vectors,
             agent_id_to_team_id=agent_id_to_team_id,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/marl/M3DDPG.py
+++ b/cares_reinforcement_learning/algorithm/marl/M3DDPG.py
@@ -60,11 +60,13 @@ It trades off optimality under nominal play
 for improved robustness under worst-case interaction.
 """
 
+from collections.abc import Callable
+
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import M3DDPGConfig
 from cares_reinforcement_learning.algorithm.marl import MADDPG
 from cares_reinforcement_learning.algorithm.policy.DDPG import DDPG
-from cares_reinforcement_learning.algorithm.configurations import M3DDPGConfig
 
 
 class M3DDPG(MADDPG):
@@ -78,6 +80,7 @@ class M3DDPG(MADDPG):
         agent_id_to_critic_id: dict[str, str],
         critic_id_to_agent_ids: dict[str, list[str]],
         config: M3DDPGConfig,
+        action_sampler: Callable[[], dict[str, torch.Tensor]],
         device: torch.device,
     ):
         super().__init__(
@@ -89,5 +92,6 @@ class M3DDPG(MADDPG):
             agent_id_to_critic_id=agent_id_to_critic_id,
             critic_id_to_agent_ids=critic_id_to_agent_ids,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )

--- a/cares_reinforcement_learning/algorithm/marl/MADDPG.py
+++ b/cares_reinforcement_learning/algorithm/marl/MADDPG.py
@@ -181,6 +181,7 @@ For cooperative environments such as simple_spread:
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -231,9 +232,15 @@ class MADDPG(MARLAlgorithm[dict[str, np.ndarray]]):
         agent_id_to_critic_id: dict[str, str],
         critic_id_to_agent_ids: dict[str, list[str]],
         config: MADDPGConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # Physical trainable containers.
         #

--- a/cares_reinforcement_learning/algorithm/marl/MAPPO.py
+++ b/cares_reinforcement_learning/algorithm/marl/MAPPO.py
@@ -288,6 +288,7 @@ Compared to deterministic methods such as MADDPG/MATD3, MAPPO is typically:
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -335,9 +336,15 @@ class MAPPO(MARLAlgorithm[dict[str, np.ndarray]]):
         agent_id_to_critic_id: dict[str, str],
         critic_id_to_agent_ids: dict[str, list[str]],
         config: MAPPOConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # Physical trainable containers.
         #

--- a/cares_reinforcement_learning/algorithm/marl/MASAC.py
+++ b/cares_reinforcement_learning/algorithm/marl/MASAC.py
@@ -233,6 +233,7 @@ Compared to MADDPG/MATD3, MASAC is typically:
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -288,9 +289,15 @@ class MASAC(MARLAlgorithm[dict[str, np.ndarray]]):
         agent_id_to_critic_id: dict[str, str],
         critic_id_to_agent_ids: dict[str, list[str]],
         config: MASACConfig,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # Physical trainable containers.
         #

--- a/cares_reinforcement_learning/algorithm/marl/MATD3.py
+++ b/cares_reinforcement_learning/algorithm/marl/MATD3.py
@@ -220,6 +220,7 @@ Compared to MADDPG, MATD3 is typically:
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -272,9 +273,15 @@ class MATD3(MARLAlgorithm[dict[str, np.ndarray]]):
         agent_id_to_critic_id: dict[str, str],
         critic_id_to_agent_ids: dict[str, list[str]],
         config: MATD3Config,
+        action_sampler: Callable[[], dict[str, np.ndarray]],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # Physical trainable containers.
         #

--- a/cares_reinforcement_learning/algorithm/marl/QMIX.py
+++ b/cares_reinforcement_learning/algorithm/marl/QMIX.py
@@ -51,6 +51,7 @@ import copy
 import logging
 import os
 import random
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -74,9 +75,15 @@ class QMIX(MARLAlgorithm[dict[str, int]]):
         network: SharedMultiAgentNetwork,
         mixer: QMixer,
         config: QMIXConfig,
+        action_sampler: Callable[[], dict[str, int]],
         device: torch.device,
     ):
-        super().__init__(policy_type="value", config=config, device=device)
+        super().__init__(
+            policy_type="value",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.network = network.to(device)
         self.target_network = copy.deepcopy(self.network).to(device)

--- a/cares_reinforcement_learning/algorithm/policy/CTD4.py
+++ b/cares_reinforcement_learning/algorithm/policy/CTD4.py
@@ -49,20 +49,20 @@ Rationale:
 CTD4 = TD3 + Gaussian distributional critics + Kalman fusion.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.algorithm.configurations import CTD4Config
 from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.algorithm.schedulers import LinearScheduler
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.CTD4 import Actor, Critic
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import CTD4Config
-from cares_reinforcement_learning.algorithm.schedulers import LinearScheduler
 
 
 class CTD4(TD3):
@@ -74,12 +74,14 @@ class CTD4(TD3):
         actor_network: Actor,
         ensemble_critic: Critic,
         config: CTD4Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=ensemble_critic,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/CrossQ.py
+++ b/cares_reinforcement_learning/algorithm/policy/CrossQ.py
@@ -55,16 +55,17 @@ CrossQ = SAC + cross-normalized critics
          enabling stable high-UTD training.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-from cares_reinforcement_learning.networks import functional as fnc
-from cares_reinforcement_learning.algorithm.policy import SAC
-from cares_reinforcement_learning.networks.CrossQ import Actor, Critic
 from cares_reinforcement_learning.algorithm.configurations import CrossQConfig
+from cares_reinforcement_learning.algorithm.policy import SAC
+from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.networks.CrossQ import Actor, Critic
 
 
 class CrossQ(SAC):
@@ -73,12 +74,14 @@ class CrossQ(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: CrossQConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/DDPG.py
+++ b/cares_reinforcement_learning/algorithm/policy/DDPG.py
@@ -49,6 +49,7 @@ DDPG = Deterministic Actor-Critic + Replay Buffer + Target Networks.
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -76,9 +77,15 @@ class DDPG(SARLAlgorithm[np.ndarray]):
         actor_network: Actor,
         critic_network: Critic,
         config: DDPGConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.actor_net = actor_network.to(self.device)
         self.critic_net = critic_network.to(self.device)

--- a/cares_reinforcement_learning/algorithm/policy/DroQ.py
+++ b/cares_reinforcement_learning/algorithm/policy/DroQ.py
@@ -53,11 +53,14 @@ DroQ = SAC + high update-to-data ratio
        + dropout-regularized critics.
 """
 
+from collections.abc import Callable
+
+import numpy as np
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import DroQConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.networks.DroQ import Actor, Critic
-from cares_reinforcement_learning.algorithm.configurations import DroQConfig
 
 
 class DroQ(SAC):
@@ -66,6 +69,7 @@ class DroQ(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: DroQConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)

--- a/cares_reinforcement_learning/algorithm/policy/LA3PSAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/LA3PSAC.py
@@ -56,6 +56,7 @@ Rationale:
 LA3P = PER + Inverse Actor Sampling + Uniform Sharing + Loss Adjustment.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -63,10 +64,10 @@ import torch
 
 import cares_reinforcement_learning.algorithm.lossess as loss
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.configurations import LA3PSACConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.memory.memory_buffer import Sample, SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.LA3PSAC import Actor, Critic
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.experience import SingleAgentExperience
@@ -78,9 +79,10 @@ class LA3PSAC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: LA3PSACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)
 
         self.prioritized_fraction = config.prioritized_fraction
 

--- a/cares_reinforcement_learning/algorithm/policy/LA3PTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/LA3PTD3.py
@@ -56,6 +56,7 @@ Rationale:
 LA3P = PER + Inverse Actor Sampling + Uniform Sharing + Loss Adjustment.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -77,9 +78,10 @@ class LA3PTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: LA3PTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)
 
         self.prioritized_fraction = config.prioritized_fraction
 

--- a/cares_reinforcement_learning/algorithm/policy/LAPSAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/LAPSAC.py
@@ -49,16 +49,16 @@ Scope:
 LAP = PER + Huber critic loss + clipped priorities.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 
 import cares_reinforcement_learning.algorithm.lossess as loss
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.configurations import LAPSACConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.LAPSAC import Actor, Critic
 
 
@@ -68,12 +68,14 @@ class LAPSAC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: LAPSACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/LAPTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/LAPTD3.py
@@ -49,6 +49,7 @@ Scope:
 LAP = PER + Huber critic loss + clipped priorities.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -66,12 +67,14 @@ class LAPTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: LAPTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/MAPERSAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/MAPERSAC.py
@@ -63,18 +63,18 @@ MaPER = PER + model-error-aware prioritization
          via shared environment prediction.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.algorithm.configurations import MAPERSACConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.MAPERSAC import Actor, Critic
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import MAPERSACConfig
 
 
 class MAPERSAC(SAC):
@@ -83,9 +83,16 @@ class MAPERSAC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: MAPERSACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(
+            actor_network=actor_network,
+            critic_network=critic_network,
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # MAPER-PER parameters
         self.scale_r = 1.0

--- a/cares_reinforcement_learning/algorithm/policy/MAPERTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/MAPERTD3.py
@@ -63,18 +63,18 @@ MaPER = PER + model-error-aware prioritization
          via shared environment prediction.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.algorithm.configurations import MAPERTD3Config
 from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.MAPERTD3 import Actor, Critic
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import MAPERTD3Config
 
 
 class MAPERTD3(TD3):
@@ -83,12 +83,14 @@ class MAPERTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: MAPERTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/NaSATD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/NaSATD3.py
@@ -79,6 +79,7 @@ NaSA-TD3 = TD3 + Autoencoder + Novelty bonus + Surprise bonus.
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -91,8 +92,6 @@ from skimage.metrics import structural_similarity as ssim
 from torch import nn
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
 from cares_reinforcement_learning.algorithm.configurations import NaSATD3Config
 from cares_reinforcement_learning.algorithm.schedulers import ExponentialScheduler
@@ -100,6 +99,7 @@ from cares_reinforcement_learning.encoders.burgess_autoencoder import BurgessAut
 from cares_reinforcement_learning.encoders.constants import Autoencoders
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import VanillaAutoencoder
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.NaSATD3 import Actor, Critic
 from cares_reinforcement_learning.networks.NaSATD3.EPDM import EPDM
 from cares_reinforcement_learning.types.action import ActionSample
@@ -116,9 +116,15 @@ class NaSATD3(SARLAlgorithm[np.ndarray]):
         actor_network: Actor,
         critic_network: Critic,
         config: NaSATD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.gamma = config.gamma
         self.tau = config.tau

--- a/cares_reinforcement_learning/algorithm/policy/PALTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/PALTD3.py
@@ -48,15 +48,16 @@ PAL = PER-compatible loss that preserves
 uniform-gradient expectation.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 import torch
 
+import cares_reinforcement_learning.algorithm.lossess as loss
+from cares_reinforcement_learning.algorithm.configurations import PALTD3Config
 from cares_reinforcement_learning.algorithm.policy import TD3
 from cares_reinforcement_learning.networks.PALTD3 import Actor, Critic
-from cares_reinforcement_learning.algorithm.configurations import PALTD3Config
-import cares_reinforcement_learning.algorithm.lossess as loss
 
 
 class PALTD3(TD3):
@@ -65,12 +66,14 @@ class PALTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: PALTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/PERSAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/PERSAC.py
@@ -33,11 +33,14 @@ Notes:
 - Corrected variants like PAL/LAP/LA3P address these issues separately.
 """
 
+from collections.abc import Callable
+
+import numpy as np
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import PERSACConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.networks.PERSAC import Actor, Critic
-from cares_reinforcement_learning.algorithm.configurations import PERSACConfig
 
 
 class PERSAC(SAC):
@@ -46,6 +49,7 @@ class PERSAC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: PERSACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)

--- a/cares_reinforcement_learning/algorithm/policy/PERTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/PERTD3.py
@@ -32,11 +32,14 @@ Notes:
 - Corrected variants like PAL/LAP/LA3P address these issues separately.
 """
 
+from collections.abc import Callable
+
+import numpy as np
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import PERTD3Config
 from cares_reinforcement_learning.algorithm.policy import TD3
 from cares_reinforcement_learning.networks.PERTD3 import Actor, Critic
-from cares_reinforcement_learning.algorithm.configurations import PERTD3Config
 
 
 class PERTD3(TD3):
@@ -45,11 +48,13 @@ class PERTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: PERTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )

--- a/cares_reinforcement_learning/algorithm/policy/PPO.py
+++ b/cares_reinforcement_learning/algorithm/policy/PPO.py
@@ -76,6 +76,7 @@ Notes:
 
 import logging
 import os
+from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from typing import Any
 
@@ -107,9 +108,15 @@ class PPO(SARLAlgorithm[np.ndarray]):
         actor_network: Actor,
         critic_network: Critic,
         config: PPOConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.actor_net = actor_network.to(device)
         self.critic_net = critic_network.to(device)

--- a/cares_reinforcement_learning/algorithm/policy/RDSAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/RDSAC.py
@@ -65,6 +65,7 @@ RD-PER = PER with Reward Prediction Error
          replacing TD-error as the priority signal.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -84,9 +85,10 @@ class RDSAC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: RDSACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)
 
         # RD-PER parameters
         self.scale_r = 1.0

--- a/cares_reinforcement_learning/algorithm/policy/RDTD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/RDTD3.py
@@ -65,6 +65,7 @@ RD-PER = PER with Reward Prediction Error
          replacing TD-error as the priority signal.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -72,11 +73,11 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.algorithm.configurations import RDTD3Config
 from cares_reinforcement_learning.algorithm.policy import TD3
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.RDTD3 import Actor, Critic
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import RDTD3Config
 
 
 class RDTD3(TD3):
@@ -85,9 +86,10 @@ class RDTD3(TD3):
         actor_network: Actor,
         critic_network: Critic,
         config: RDTD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(actor_network, critic_network, config, device)
+        super().__init__(actor_network, critic_network, config, action_sampler, device)
         # RD-PER parameters
         self.scale_r = 1.0
         self.scale_s = 1.0

--- a/cares_reinforcement_learning/algorithm/policy/REDQ.py
+++ b/cares_reinforcement_learning/algorithm/policy/REDQ.py
@@ -54,6 +54,7 @@ REDQ = SAC + Large Q-ensemble + Randomized subset
         minimization + High update-to-data ratio.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -61,14 +62,13 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
+from cares_reinforcement_learning.algorithm.configurations import REDQConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.REDQ import Actor, Critic
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import REDQConfig
 
 
 class REDQ(SAC):
@@ -80,12 +80,14 @@ class REDQ(SAC):
         actor_network: Actor,
         ensemble_critic: Critic,
         config: REDQConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=ensemble_critic,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/policy/SAC.py
+++ b/cares_reinforcement_learning/algorithm/policy/SAC.py
@@ -57,6 +57,7 @@ SAC = Maximum-Entropy RL + Twin Q Critics + Replay Buffer.
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -87,9 +88,15 @@ class SAC(SARLAlgorithm[np.ndarray]):
         actor_network: TanhGaussianPolicy,
         critic_network: TwinQNetwork | EnsembleCritic,
         config: SACConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.gamma = config.gamma
         self.tau = config.tau

--- a/cares_reinforcement_learning/algorithm/policy/SACAE.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACAE.py
@@ -60,6 +60,7 @@ SAC-AE = SAC + shared convolutional encoder +
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -67,12 +68,12 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
+from cares_reinforcement_learning.algorithm.configurations import SACAEConfig
 from cares_reinforcement_learning.encoders.losses import AELoss
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.SACAE import Actor, Critic
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
@@ -80,7 +81,6 @@ from cares_reinforcement_learning.types.observation import (
     SARLObservation,
     SARLObservationTensors,
 )
-from cares_reinforcement_learning.algorithm.configurations import SACAEConfig
 
 
 class SACAE(SARLAlgorithm[np.ndarray]):
@@ -90,9 +90,15 @@ class SACAE(SARLAlgorithm[np.ndarray]):
         critic_network: Critic,
         decoder_network: Decoder,
         config: SACAEConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # this may be called policy_net in other implementations
         self.actor_net = actor_network.to(device)

--- a/cares_reinforcement_learning/algorithm/policy/SACD.py
+++ b/cares_reinforcement_learning/algorithm/policy/SACD.py
@@ -65,6 +65,7 @@ SACD = SAC with categorical policy +
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -72,15 +73,14 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
+from cares_reinforcement_learning.algorithm.configurations import SACDConfig
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.SACD import Actor, Critic
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import SACDConfig
 
 
 class SACD(SARLAlgorithm[int]):
@@ -89,9 +89,15 @@ class SACD(SARLAlgorithm[int]):
         actor_network: Actor,
         critic_network: Critic,
         config: SACDConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(policy_type="discrete_policy", config=config, device=device)
+        super().__init__(
+            policy_type="discrete_policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # this may be called policy_net in other implementations
         self.actor_net = actor_network.to(device)

--- a/cares_reinforcement_learning/algorithm/policy/SDAR.py
+++ b/cares_reinforcement_learning/algorithm/policy/SDAR.py
@@ -57,6 +57,7 @@ SDAR = closed-loop, per-dimension action repetition
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -64,15 +65,14 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
+from cares_reinforcement_learning.algorithm.configurations import SDARConfig
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.SDAR import Actor, Critic
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import SDARConfig
 
 
 class SDAR(SARLAlgorithm[np.ndarray]):
@@ -84,9 +84,15 @@ class SDAR(SARLAlgorithm[np.ndarray]):
         actor_network: Actor,
         critic_network: Critic,
         config: SDARConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         # SAC-style initialization
         self.gamma = config.gamma

--- a/cares_reinforcement_learning/algorithm/policy/TD3.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD3.py
@@ -49,6 +49,7 @@ TD3 = DDPG + twin critics + target action smoothing + delayed actor/target updat
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -56,12 +57,11 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
 from cares_reinforcement_learning.algorithm.configurations import TD3Config
 from cares_reinforcement_learning.algorithm.schedulers import ExponentialScheduler
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.common import (
     DeterministicPolicy,
     EnsembleCritic,
@@ -81,9 +81,15 @@ class TD3(SARLAlgorithm[np.ndarray]):
         actor_network: DeterministicPolicy,
         critic_network: TwinQNetwork | EnsembleCritic,
         config: TD3Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.actor_net = actor_network.to(device)
         self.critic_net = critic_network.to(device)

--- a/cares_reinforcement_learning/algorithm/policy/TD3AE.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD3AE.py
@@ -59,6 +59,7 @@ TD3-AE = TD3 + shared convolutional encoder +
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -66,14 +67,13 @@ import torch
 import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
 from cares_reinforcement_learning.algorithm.configurations import TD3AEConfig
 from cares_reinforcement_learning.algorithm.schedulers import ExponentialScheduler
 from cares_reinforcement_learning.encoders.losses import AELoss
 from cares_reinforcement_learning.encoders.vanilla_autoencoder import Decoder
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.TD3AE import Actor, Critic
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
@@ -90,9 +90,15 @@ class TD3AE(SARLAlgorithm[np.ndarray]):
         critic_network: Critic,
         decoder_network: Decoder,
         config: TD3AEConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.actor_net = actor_network.to(self.device)
         self.critic_net = critic_network.to(self.device)

--- a/cares_reinforcement_learning/algorithm/policy/TD7.py
+++ b/cares_reinforcement_learning/algorithm/policy/TD7.py
@@ -102,6 +102,7 @@ stability- and representation-focused redesign.
 import copy
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -110,12 +111,11 @@ import torch.nn.functional as F
 
 import cares_reinforcement_learning.algorithm.lossess as loss
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
-import cares_reinforcement_learning.util.helpers as hlp
-from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
 from cares_reinforcement_learning.algorithm.configurations import TD7Config
 from cares_reinforcement_learning.algorithm.schedulers import ExponentialScheduler
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
+from cares_reinforcement_learning.networks import functional as fnc
 from cares_reinforcement_learning.networks.TD7 import Actor, Critic, Encoder
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
@@ -129,9 +129,15 @@ class TD7(SARLAlgorithm[np.ndarray]):
         critic_network: Critic,
         encoder_network: Encoder,
         config: TD7Config,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="policy", config=config, device=device)
+        super().__init__(
+            policy_type="policy",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.actor_net = actor_network.to(device)
         self.critic_net = critic_network.to(device)

--- a/cares_reinforcement_learning/algorithm/policy/TQC.py
+++ b/cares_reinforcement_learning/algorithm/policy/TQC.py
@@ -54,6 +54,7 @@ TQC = SAC + distributional critics +
       quantile truncation for conservative targets.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -73,12 +74,14 @@ class TQC(SAC):
         actor_network: Actor,
         critic_network: Critic,
         config: TQCConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
         super().__init__(
             actor_network=actor_network,
             critic_network=critic_network,
             config=config,
+            action_sampler=action_sampler,
             device=device,
         )
 

--- a/cares_reinforcement_learning/algorithm/usd/DADS.py
+++ b/cares_reinforcement_learning/algorithm/usd/DADS.py
@@ -71,6 +71,7 @@ DADS = skill discovery via maximizing
 import logging
 import math
 import os
+from collections.abc import Callable
 from dataclasses import replace
 from typing import Any
 
@@ -78,6 +79,7 @@ import numpy as np
 import torch
 
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
+from cares_reinforcement_learning.algorithm.configurations import DADSConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.memory import memory_sampler
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
@@ -85,7 +87,6 @@ from cares_reinforcement_learning.networks.DADS import SkillDynamicsModel
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import DADSConfig
 
 
 class DADS(SARLAlgorithm[np.ndarray]):
@@ -94,9 +95,15 @@ class DADS(SARLAlgorithm[np.ndarray]):
         skills_agent: SAC,
         discriminator_network: SkillDynamicsModel,
         config: DADSConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="usd", config=config, device=device)
+        super().__init__(
+            policy_type="usd",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.skills_agent = skills_agent
         self.discriminator_net = discriminator_network.to(device)

--- a/cares_reinforcement_learning/algorithm/usd/DIAYN.py
+++ b/cares_reinforcement_learning/algorithm/usd/DIAYN.py
@@ -55,6 +55,7 @@ DIAYN = unsupervised skill learning via
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import replace
 from typing import Any
 
@@ -64,13 +65,13 @@ import torch.nn.functional as F
 
 import cares_reinforcement_learning.memory.memory_sampler as memory_sampler
 from cares_reinforcement_learning.algorithm.algorithm import SARLAlgorithm
+from cares_reinforcement_learning.algorithm.configurations import DIAYNConfig
 from cares_reinforcement_learning.algorithm.policy import SAC
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
 from cares_reinforcement_learning.networks.DIAYN import Discriminator
 from cares_reinforcement_learning.types.action import ActionSample
 from cares_reinforcement_learning.types.episode import EpisodeContext
 from cares_reinforcement_learning.types.observation import SARLObservation
-from cares_reinforcement_learning.algorithm.configurations import DIAYNConfig
 
 
 class DIAYN(SARLAlgorithm[np.ndarray]):
@@ -79,9 +80,15 @@ class DIAYN(SARLAlgorithm[np.ndarray]):
         skills_agent: SAC,
         discriminator_network: Discriminator,
         config: DIAYNConfig,
+        action_sampler: Callable[[], np.ndarray],
         device: torch.device,
     ):
-        super().__init__(policy_type="usd", config=config, device=device)
+        super().__init__(
+            policy_type="usd",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.skills_agent = skills_agent
         self.discriminator_net = discriminator_network.to(device)

--- a/cares_reinforcement_learning/algorithm/value/C51.py
+++ b/cares_reinforcement_learning/algorithm/value/C51.py
@@ -49,17 +49,18 @@ C51 = DQN + categorical distributional value learning
       with fixed support and projection.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
 
-from cares_reinforcement_learning.algorithm.value import DQN
-from cares_reinforcement_learning.networks.C51 import Network as C51Network
-from cares_reinforcement_learning.networks.Rainbow import Network as RainbowNetwork
 from cares_reinforcement_learning.algorithm.configurations import (
     C51Config,
     RainbowConfig,
 )
+from cares_reinforcement_learning.algorithm.value import DQN
+from cares_reinforcement_learning.networks.C51 import Network as C51Network
+from cares_reinforcement_learning.networks.Rainbow import Network as RainbowNetwork
 
 
 class C51(DQN):
@@ -70,9 +71,12 @@ class C51(DQN):
         self,
         network: C51Network | RainbowNetwork,
         config: C51Config | RainbowConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network=network, config=config, device=device)
+        super().__init__(
+            network=network, config=config, action_sampler=action_sampler, device=device
+        )
 
         # C51
         self.num_atoms = config.num_atoms

--- a/cares_reinforcement_learning/algorithm/value/DQN.py
+++ b/cares_reinforcement_learning/algorithm/value/DQN.py
@@ -50,6 +50,7 @@ import copy
 import logging
 import os
 import random
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -72,9 +73,15 @@ class DQN(SARLAlgorithm[int]):
         self,
         network: BaseNetwork,
         config: DQNConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(policy_type="value", config=config, device=device)
+        super().__init__(
+            policy_type="value",
+            config=config,
+            action_sampler=action_sampler,
+            device=device,
+        )
 
         self.network = network.to(device)
         self.target_network = copy.deepcopy(self.network).to(device)

--- a/cares_reinforcement_learning/algorithm/value/DoubleDQN.py
+++ b/cares_reinforcement_learning/algorithm/value/DoubleDQN.py
@@ -44,11 +44,13 @@ Double DQN = DQN with decoupled action selection
              and action evaluation in the target.
 """
 
+from collections.abc import Callable
+
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import DoubleDQNConfig
 from cares_reinforcement_learning.algorithm.value import DQN
 from cares_reinforcement_learning.networks.DoubleDQN import Network
-from cares_reinforcement_learning.algorithm.configurations import DoubleDQNConfig
 
 
 class DoubleDQN(DQN):
@@ -56,6 +58,7 @@ class DoubleDQN(DQN):
         self,
         network: Network,
         config: DoubleDQNConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network, config, device)
+        super().__init__(network, config, action_sampler, device)

--- a/cares_reinforcement_learning/algorithm/value/DuelingDQN.py
+++ b/cares_reinforcement_learning/algorithm/value/DuelingDQN.py
@@ -46,11 +46,13 @@ Key Behaviour:
 Dueling DQN = DQN with separate value and advantage streams.
 """
 
+from collections.abc import Callable
+
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import DuelingDQNConfig
 from cares_reinforcement_learning.algorithm.value import DQN
 from cares_reinforcement_learning.networks.DuelingDQN import Network
-from cares_reinforcement_learning.algorithm.configurations import DuelingDQNConfig
 
 
 class DuelingDQN(DQN):
@@ -58,6 +60,7 @@ class DuelingDQN(DQN):
         self,
         network: Network,
         config: DuelingDQNConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network, config, device)
+        super().__init__(network, config, action_sampler, device)

--- a/cares_reinforcement_learning/algorithm/value/NoisyNet.py
+++ b/cares_reinforcement_learning/algorithm/value/NoisyNet.py
@@ -53,13 +53,15 @@ NoisyNet = neural networks with learnable parameter noise
            for adaptive exploration.
 """
 
+from collections.abc import Callable
+
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import NoisyNetConfig
 from cares_reinforcement_learning.algorithm.value import DQN
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
 from cares_reinforcement_learning.networks.NoisyNet import BaseNoisyNetwork
 from cares_reinforcement_learning.types.episode import EpisodeContext
-from cares_reinforcement_learning.algorithm.configurations import NoisyNetConfig
 
 
 class NoisyNet(DQN):
@@ -70,9 +72,12 @@ class NoisyNet(DQN):
         self,
         network: BaseNoisyNetwork,
         config: NoisyNetConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network=network, config=config, device=device)
+        super().__init__(
+            network=network, config=config, action_sampler=action_sampler, device=device
+        )
 
     def _reset_noise(self):
         self.network.reset_noise()

--- a/cares_reinforcement_learning/algorithm/value/PERDQN.py
+++ b/cares_reinforcement_learning/algorithm/value/PERDQN.py
@@ -44,11 +44,13 @@ Advantages:
 PER-DQN = DQN + prioritized replay + importance weighting.
 """
 
+from collections.abc import Callable
+
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import PERDQNConfig
 from cares_reinforcement_learning.algorithm.value import DQN
 from cares_reinforcement_learning.networks.PERDQN import Network
-from cares_reinforcement_learning.algorithm.configurations import PERDQNConfig
 
 
 class PERDQN(DQN):
@@ -56,6 +58,9 @@ class PERDQN(DQN):
         self,
         network: Network,
         config: PERDQNConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network=network, config=config, device=device)
+        super().__init__(
+            network=network, config=config, action_sampler=action_sampler, device=device
+        )

--- a/cares_reinforcement_learning/algorithm/value/QRDQN.py
+++ b/cares_reinforcement_learning/algorithm/value/QRDQN.py
@@ -45,6 +45,7 @@ Key Behaviour:
 QR-DQN = DQN + quantile-based distributional value learning.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -63,9 +64,12 @@ class QRDQN(DQN):
         self,
         network: Network,
         config: QRDQNConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network=network, config=config, device=device)
+        super().__init__(
+            network=network, config=config, action_sampler=action_sampler, device=device
+        )
 
         # QRDQN
         self.kappa = config.kappa

--- a/cares_reinforcement_learning/algorithm/value/Rainbow.py
+++ b/cares_reinforcement_learning/algorithm/value/Rainbow.py
@@ -60,15 +60,16 @@ Rainbow = a unified, multi-component enhancement
            of the original DQN framework.
 """
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
 
+from cares_reinforcement_learning.algorithm.configurations import RainbowConfig
 from cares_reinforcement_learning.algorithm.value import C51
 from cares_reinforcement_learning.memory.memory_buffer import SARLMemoryBuffer
 from cares_reinforcement_learning.networks.Rainbow import Network
 from cares_reinforcement_learning.types.episode import EpisodeContext
-from cares_reinforcement_learning.algorithm.configurations import RainbowConfig
 
 
 class Rainbow(C51):
@@ -79,9 +80,12 @@ class Rainbow(C51):
         self,
         network: Network,
         config: RainbowConfig,
+        action_sampler: Callable[[], int],
         device: torch.device,
     ):
-        super().__init__(network=network, config=config, device=device)
+        super().__init__(
+            network=network, config=config, action_sampler=action_sampler, device=device
+        )
 
     def _reset_noise(self) -> None:
         self.network.reset_noise()

--- a/cares_reinforcement_learning/runners/base_runner.py
+++ b/cares_reinforcement_learning/runners/base_runner.py
@@ -164,7 +164,10 @@ class BaseRunner(ABC):
             f"[SEED {self.train_seed} | {self.eval_seed}] Algorithm: {self.alg_config.algorithm}"
         )
         self.agent: Algorithm = self.algorithm_factory.create_network(
-            self.env.observation_space, self.env.action_num, self.alg_config
+            self.env.observation_space,
+            self.env.action_num,
+            self.alg_config,
+            self.env.sample_action,
         )
 
         # Validate agent creation

--- a/cares_reinforcement_learning/runners/training_runner.py
+++ b/cares_reinforcement_learning/runners/training_runner.py
@@ -166,10 +166,6 @@ class TrainingRunner(BaseRunner):
                 }
             )
 
-    def _select_exploration_action(self, train_step_counter: int) -> ActionSample:
-        """Handle exploration phase action selection."""
-        return ActionSample(self.env.sample_action(), source="exploration")
-
     def _select_repetition_action(self, episode_timesteps: int) -> ActionSample:
         """Handle episode repetition action selection."""
         action = self.repetition_manager.get_repetition_action(episode_timesteps)
@@ -182,12 +178,8 @@ class TrainingRunner(BaseRunner):
 
         return action
 
-    def _select_action(
-        self, train_step_counter: int, episode_step: int, state
-    ) -> ActionSample:
-        if train_step_counter < self.max_steps_exploration:
-            action = self._select_exploration_action(train_step_counter)
-        elif self.repetition_manager.should_repeat(episode_step):
+    def _select_action(self, episode_step: int, state) -> ActionSample:
+        if self.repetition_manager.should_repeat(episode_step):
             action = self._select_repetition_action(episode_step)
         else:
             action = self._select_policy_action(state)
@@ -254,9 +246,7 @@ class TrainingRunner(BaseRunner):
             episode_stats.step()
 
             # Determine action based on training phase
-            action_sample = self._select_action(
-                train_step_counter, episode_stats.steps, state
-            )
+            action_sample = self._select_action(episode_stats.steps, state)
 
             # Record action and execute step
             self.repetition_manager.record_action(action_sample)

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -184,7 +184,10 @@ def test_algorithms(tmp_path):
             }
 
         agent = factory.create_network(
-            observation_size=observation_size, action_num=action_num, config=alg_config
+            observation_size=observation_size,
+            action_num=action_num,
+            config=alg_config,
+            action_sampler=None,
         )
         assert agent is not None, f"{algorithm} was not created successfully"
 


### PR DESCRIPTION
Alogrithms require detailed control over whether they are exploration (env.sample_action) or generating the actions with the actor - passing action_sampler from the envrionments allows more control over how that is handled in each algorithms act method. 

Clearer act logic across all algorithms without the globally shared hidden exploration in the training loop. 